### PR TITLE
Only minimize app on pop when there is no route to pop

### DIFF
--- a/lib/ui/with_foreground_task.dart
+++ b/lib/ui/with_foreground_task.dart
@@ -18,7 +18,8 @@ class WithForegroundTask extends StatefulWidget {
 
 class _WithForegroundTaskState extends State<WithForegroundTask> {
   Future<bool> _onWillPop() async {
-    if (await FlutterForegroundTask.isRunningService) {
+    if (!Navigator.canPop(context) &&
+        await FlutterForegroundTask.isRunningService) {
       FlutterForegroundTask.minimizeApp();
       return false;
     }


### PR DESCRIPTION
This is a potential fix to https://github.com/Dev-hwang/flutter_foreground_task/issues/42 it works for my own project, although of course there are a lot of things to deal with if your app was formerly stopping and is now being force-closed.