### PR TITLE
Add notification press handler, fixes #41

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,16 @@ class FirstTaskHandler extends TaskHandler {
     // Called when the notification button on the Android platform is pressed.
     print('onButtonPressed >> $id');
   }
+
+  @override
+  void onNotificationPressed() {
+    // Called when the notification itself on the Android platform is pressed.
+    FlutterForegroundTask.launchApp("/resume-route");
+    // Note that the app will only route to "/resume-route" when it is exited so
+    // it will usually be necessary to send a message through the send port to
+    // signal it to restore state when the app is already started
+    print('onNotificationPressed');
+  }
 }
 
 class ExampleApp extends StatefulWidget {
@@ -575,6 +585,19 @@ import 'package:flutter_foreground_task/flutter_foreground_task.dart';
 
 void function() => FlutterForegroundTask.minimizeApp();
 ```
+
+### :lollipop: launchApp (Android)
+
+Launch the app if it is not running otherwise open the current activity.
+
+```dart
+import 'package:flutter_foreground_task/flutter_foreground_task.dart';
+
+void function() => FlutterForegroundTask.launchApp();
+```
+
+It is also possible to pass a route to this function but the route will only
+be loaded if the app is not already running.
 
 ### :lollipop: wakeUpScreen (Android)
 

--- a/android/src/main/kotlin/com/pravera/flutter_foreground_task/MethodCallHandlerImpl.kt
+++ b/android/src/main/kotlin/com/pravera/flutter_foreground_task/MethodCallHandlerImpl.kt
@@ -48,6 +48,10 @@ class MethodCallHandlerImpl(private val context: Context, private val provider: 
 			"isRunningService" ->
 				result.success(provider.getForegroundServiceManager().isRunningService())
 			"minimizeApp" -> ForegroundServiceUtils.minimizeApp(activity)
+			"launchApp" -> {
+				val args = call.arguments<List<String?>>()
+				ForegroundServiceUtils.launchApp(context, args.getOrNull(0))
+			}
 			"wakeUpScreen" -> ForegroundServiceUtils.wakeUpScreen(context)
 			"isIgnoringBatteryOptimizations" ->
 				result.success(ForegroundServiceUtils.isIgnoringBatteryOptimizations(context))

--- a/android/src/main/kotlin/com/pravera/flutter_foreground_task/service/ForegroundService.kt
+++ b/android/src/main/kotlin/com/pravera/flutter_foreground_task/service/ForegroundService.kt
@@ -35,6 +35,7 @@ class ForegroundService: Service(), MethodChannel.MethodCallHandler {
 		private const val TAG = "ForegroundService"
 
 		private const val BUTTON_PRESSED_ACTION = "onButtonPressed"
+		private const val NOTIFICATION_PRESSED_ACTION = "onNotificationPressed"
 		private const val ACTION_DATA_NAME = "data"
 
 		/** Returns whether the foreground service is running. */
@@ -168,6 +169,7 @@ class ForegroundService: Service(), MethodChannel.MethodCallHandler {
 	private fun registerBroadcastReceiver() {
 		val intentFilter = IntentFilter().apply {
 			addAction(BUTTON_PRESSED_ACTION)
+			addAction(NOTIFICATION_PRESSED_ACTION)
 		}
 		registerReceiver(broadcastReceiver, intentFilter)
 	}
@@ -198,7 +200,7 @@ class ForegroundService: Service(), MethodChannel.MethodCallHandler {
 			getAppIconResourceId(pm)
 		else
 			getDrawableResourceId(iconResType, iconResPrefix, iconName)
-		val pendingIntent = getPendingIntent(pm)
+		val pendingIntent = getPendingIntent()
 
 		// Create a notification and start the foreground service.
 		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
@@ -418,12 +420,12 @@ class ForegroundService: Service(), MethodChannel.MethodCallHandler {
 		}
 	}
 
-	private fun getPendingIntent(pm: PackageManager): PendingIntent {
-		val launchIntent = pm.getLaunchIntentForPackage(applicationContext.packageName)
+	private fun getPendingIntent(): PendingIntent {
+		val pressedIntent = Intent(NOTIFICATION_PRESSED_ACTION)
 		return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-			PendingIntent.getActivity(this, 0, launchIntent, PendingIntent.FLAG_IMMUTABLE)
+			PendingIntent.getBroadcast(this, 20000, pressedIntent, PendingIntent.FLAG_IMMUTABLE)
 		} else {
-			PendingIntent.getActivity(this, 0, launchIntent, 0)
+			PendingIntent.getBroadcast(this, 20000, pressedIntent, 0)
 		}
 	}
 

--- a/android/src/main/kotlin/com/pravera/flutter_foreground_task/utils/ForegroundServiceUtils.kt
+++ b/android/src/main/kotlin/com/pravera/flutter_foreground_task/utils/ForegroundServiceUtils.kt
@@ -26,6 +26,24 @@ class ForegroundServiceUtils {
 		}
 
 		/**
+		 * Launch the app at `route` if it is not running otherwise open it
+		 *
+		 * @param context context
+		 * @param route Open this route if the app is closed
+		 */
+		fun launchApp(context: Context, route: String?) {
+			val pm = context.packageManager
+			val launchIntent = pm.getLaunchIntentForPackage(context.packageName)
+			if (launchIntent != null) {
+				launchIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+				if (route != null) {
+					launchIntent.putExtra("route", route)
+				}
+				context.startActivity(launchIntent)
+			}
+		}
+
+		/**
 		 * Wake up the screen of a device that is turned off.
 		 *
 		 * @param context context

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -47,6 +47,12 @@ class FirstTaskHandler extends TaskHandler {
     // Called when the notification button on the Android platform is pressed.
     print('onButtonPressed >> $id');
   }
+
+  @override
+  void onNotificationPressed() {
+    // Called when the notification itself on the Android platform is pressed.
+    print('onNotificationPressed');
+  }
 }
 
 void updateCallback() {
@@ -55,9 +61,7 @@ void updateCallback() {
 
 class SecondTaskHandler extends TaskHandler {
   @override
-  Future<void> onStart(DateTime timestamp, SendPort? sendPort) async {
-
-  }
+  Future<void> onStart(DateTime timestamp, SendPort? sendPort) async {}
 
   @override
   Future<void> onEvent(DateTime timestamp, SendPort? sendPort) async {
@@ -70,9 +74,7 @@ class SecondTaskHandler extends TaskHandler {
   }
 
   @override
-  Future<void> onDestroy(DateTime timestamp) async {
-
-  }
+  Future<void> onDestroy(DateTime timestamp) async {}
 }
 
 class ExampleApp extends StatefulWidget {

--- a/lib/flutter_foreground_task.dart
+++ b/lib/flutter_foreground_task.dart
@@ -41,6 +41,11 @@ abstract class TaskHandler {
 
   /// Called when the notification button on the Android platform is pressed.
   void onButtonPressed(String id) {}
+
+  /// Called when the notification itself on the Android platform is pressed.
+  void onNotificationPressed() {
+    FlutterForegroundTask.launchApp();
+  }
 }
 
 /// A class that implements foreground task and provides useful utilities.
@@ -256,6 +261,14 @@ class FlutterForegroundTask {
   /// Minimize the app to the background.
   static void minimizeApp() => _methodChannel.invokeMethod('minimizeApp');
 
+  /// Launch the app at `route` if it is not running otherwise open it
+  static void launchApp([String? route]) {
+    // This function only works on Android.
+    if (!Platform.isAndroid) return;
+
+    _methodChannel.invokeMethod('launchApp', [route]);
+  }
+
   /// Wake up the screen of a device that is turned off.
   static void wakeUpScreen() {
     // This function only works on Android.
@@ -314,6 +327,8 @@ class FlutterForegroundTask {
           return await handler.onDestroy(timestamp);
         case 'onButtonPressed':
           return handler.onButtonPressed(call.arguments.toString());
+        case 'onNotificationPressed':
+          return handler.onNotificationPressed();
       }
     });
 


### PR DESCRIPTION
Fixes https://github.com/Dev-hwang/flutter_foreground_task/issues/41

The idea is:

1. If the app has exited then `FlutterForegroundTask.launchApp("/some-route")` can be used to launch to a route that will restore the desired state from shared preferences or whatever (when the app is already open then this method will just open maximise the app window at whatever route is already loaded).
2. If the app is already running then the send port can be used to send a message from the isolate to the activity which can set whatever context is needed from state that has probably already been loaded.

In my app I'm doing this:

```dart
  @override
  void onNotificationPressed() {
    FlutterForegroundTask.launchApp('/redirect-to-wifi-report');
    _sendPort?.send('notificationPressed');
  }
```

Then my receive port listener looks like this  (where `_openWifiReport` can use data that has already been loaded so is very efficient):

```dart
  void _listenToReceivePort() {
    _receivePort!.listen((message) {
      if (message is String) {
        if (message == 'stop') {
          _openWifiReport();
          stop();
        } else if (message == 'notificationPressed') {
          _openWifiReport();
        }
      }
    });
  }
```

and my page which handles `'/redirect-to-wifi-report'` looks like this:

```dart
class WifiRedirectToReport extends StatelessWidget {
  const WifiRedirectToReport({Key? key}) : super(key: key);

  @override
  Widget build(BuildContext context) {
    Future.microtask(() async {
      final wifiReportStatus = context.read<WifiReportStatus>();
      await wifiReportStatus.initialized;

      if (wifiReportStatus.active) {
        Navigator.pushReplacementNamed(
          context,
          '/wifi-report',
          arguments: wifiReportStatus.arguments
        );
      } else {
        Navigator.pushReplacementNamed(context, '/');
      }
    });

    return const Center(
      child: CircularProgressIndicator(),
    );
  }
}
```

Anyone who wants to try this branch can add the following to their `pubspec.yaml`

```yaml
  flutter_foreground_task:
    git:
      url: git@github.com:sol-x/flutter_foreground_task
      ref: feature/41
```