### PR TITLE
Exit the process when its termintated along with the task

### DIFF
--- a/android/src/main/kotlin/com/pravera/flutter_foreground_task/service/ForegroundService.kt
+++ b/android/src/main/kotlin/com/pravera/flutter_foreground_task/service/ForegroundService.kt
@@ -22,6 +22,7 @@ import io.flutter.plugin.common.MethodChannel
 import io.flutter.view.FlutterCallbackInformation
 import kotlinx.coroutines.*
 import java.util.*
+import kotlin.system.exitProcess
 
 private val TAG = ForegroundService::class.java.simpleName
 private const val ACTION_TASK_START = "onStart"
@@ -40,7 +41,7 @@ private const val DATA_FIELD_NAME = "data"
 class ForegroundService: Service(), MethodChannel.MethodCallHandler {
 	companion object {
 		/** Returns whether the foreground service is running. */
-		var isRunningService = false 
+		var isRunningService = false
 			private set
 	}
 
@@ -118,20 +119,20 @@ class ForegroundService: Service(), MethodChannel.MethodCallHandler {
 		releaseLockMode()
 		destroyForegroundTask()
 		unregisterBroadcastReceiver()
-		if (!isSetStopWithTaskFlag() && foregroundServiceStatus.action != ForegroundServiceAction.STOP) {
-			Log.i(TAG, "The foreground service was terminated due to an unexpected problem.")
-			if (notificationOptions.isSticky) {
-				if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-					if (!ForegroundServiceUtils.isIgnoringBatteryOptimizations(applicationContext)) {
-						Log.i(TAG, "Turn off battery optimization to restart service in the background.")
-						return
-					}
-				}
-
-				setRestartAlarm()
+		if (foregroundServiceStatus.action != ForegroundServiceAction.STOP) {
+			if (isSetStopWithTaskFlag()) {
+				exitProcess(0)
 			} else {
-				// exitProcess(0)
-				return
+				Log.i(TAG, "The foreground service was terminated due to an unexpected problem.")
+				if (notificationOptions.isSticky) {
+					if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+						if (!ForegroundServiceUtils.isIgnoringBatteryOptimizations(applicationContext)) {
+							Log.i(TAG, "Turn off battery optimization to restart service in the background.")
+							return
+						}
+					}
+					setRestartAlarm()
+				}
 			}
 		}
 	}
@@ -178,8 +179,8 @@ class ForegroundService: Service(), MethodChannel.MethodCallHandler {
 			)
 		}
 		val iconResId = if (iconResType.isNullOrEmpty()
-				|| iconResPrefix.isNullOrEmpty()
-				|| iconName.isNullOrEmpty())
+			|| iconResPrefix.isNullOrEmpty()
+			|| iconName.isNullOrEmpty())
 			getAppIconResourceId(pm)
 		else
 			getDrawableResourceId(iconResType, iconResPrefix, iconName)


### PR DESCRIPTION
The premise:
When android:stopWithTask="true" flag is set in the manifest for the service, closing the app causes the notification and the service to disappear and the activity is destroyed along with the service but the app keeps running in the background.

Assurances:

Exiting the process only if the flag is set and the activity is destroyed.
Removing the flag from the manifest stops this behavior.