### PR TITLE
Fix #183.

### DIFF
--- a/android/src/main/kotlin/com/pravera/flutter_foreground_task/MethodCallHandlerImpl.kt
+++ b/android/src/main/kotlin/com/pravera/flutter_foreground_task/MethodCallHandlerImpl.kt
@@ -60,6 +60,10 @@ class MethodCallHandlerImpl(private val context: Context, private val provider: 
                 result.success(provider.getForegroundServiceManager().update(context, args))
             "stopService" ->
                 result.success(provider.getForegroundServiceManager().stop(context))
+            "notification" ->
+                result.success(provider.getForegroundServiceManager().notify(context, args))
+            "sendMessage" ->
+                result.success(provider.getForegroundServiceManager().message(context, args))
             "isRunningService" ->
                 result.success(provider.getForegroundServiceManager().isRunningService())
             "attachedActivity" -> result.success(activity != null)

--- a/android/src/main/kotlin/com/pravera/flutter_foreground_task/models/ForegroundServiceAction.kt
+++ b/android/src/main/kotlin/com/pravera/flutter_foreground_task/models/ForegroundServiceAction.kt
@@ -14,4 +14,6 @@ object ForegroundServiceAction {
 	const val REBOOT = prefix + "reboot"
 	const val RESTART = prefix + "restart"
 	const val STOP = prefix + "stop"
+	const val NOTIFY = prefix + "notify"
+	const val MESSAGE = prefix + "message"
 }

--- a/android/src/main/kotlin/com/pravera/flutter_foreground_task/models/NotificationOptions.kt
+++ b/android/src/main/kotlin/com/pravera/flutter_foreground_task/models/NotificationOptions.kt
@@ -160,9 +160,14 @@ data class NotificationOptions(
             val prefs = context.getSharedPreferences(
                 PrefsKey.NOTIFICATION_OPTIONS_PREFS, Context.MODE_PRIVATE)
 
-            val id = map?.get(PrefsKey.NOTIFICATION_ID) as? Int ?: 1000
-            val contentTitle = map?.get(PrefsKey.NOTIFICATION_CONTENT_TITLE) as? String ?: ""
-            val contentText = map?.get(PrefsKey.NOTIFICATION_CONTENT_TEXT) as? String ?: ""
+            val id = map?.get(PrefsKey.NOTIFICATION_ID) as? Int
+                ?: prefs.getInt(PrefsKey.NOTIFICATION_ID, 1000);
+            val contentTitle = map?.get(PrefsKey.NOTIFICATION_CONTENT_TITLE) as? String
+                ?: prefs.getString(PrefsKey.NOTIFICATION_CONTENT_TITLE, null)
+                ?: ""
+            val contentText = map?.get(PrefsKey.NOTIFICATION_CONTENT_TEXT) as? String
+                ?: prefs.getString(PrefsKey.NOTIFICATION_CONTENT_TEXT, null)
+                ?: ""
 
             val iconData = map?.get(PrefsKey.ICON_DATA) as? Map<*, *>
             var iconDataJson: String? = null

--- a/android/src/main/kotlin/com/pravera/flutter_foreground_task/models/NotificationOptions.kt
+++ b/android/src/main/kotlin/com/pravera/flutter_foreground_task/models/NotificationOptions.kt
@@ -156,6 +156,36 @@ data class NotificationOptions(
             }
         }
 
+        fun notificationContent(context: Context, map: Map<*, *>?) {
+            val prefs = context.getSharedPreferences(
+                PrefsKey.NOTIFICATION_OPTIONS_PREFS, Context.MODE_PRIVATE)
+
+            val id = map?.get(PrefsKey.NOTIFICATION_ID) as? Int ?: 1000
+            val contentTitle = map?.get(PrefsKey.NOTIFICATION_CONTENT_TITLE) as? String ?: ""
+            val contentText = map?.get(PrefsKey.NOTIFICATION_CONTENT_TEXT) as? String ?: ""
+
+            val iconData = map?.get(PrefsKey.ICON_DATA) as? Map<*, *>
+            var iconDataJson: String? = null
+            if (iconData != null) {
+                iconDataJson = JSONObject(iconData).toString()
+            }
+
+            val buttons = map?.get(PrefsKey.BUTTONS) as? List<*>
+            var buttonsJson: String? = null
+            if (buttons != null) {
+                buttonsJson = JSONArray(buttons).toString()
+            }
+
+            with(prefs.edit()) {
+                putInt(PrefsKey.NOTIFICATION_ID, id)
+                putString(PrefsKey.NOTIFICATION_CONTENT_TITLE, contentTitle)
+                putString(PrefsKey.NOTIFICATION_CONTENT_TEXT, contentText)
+                putString(PrefsKey.ICON_DATA, iconDataJson)
+                putString(PrefsKey.BUTTONS, buttonsJson)
+                commit()
+            }
+        }
+
         fun clearData(context: Context) {
             val prefs = context.getSharedPreferences(
                 PrefsKey.NOTIFICATION_OPTIONS_PREFS, Context.MODE_PRIVATE)

--- a/android/src/main/kotlin/com/pravera/flutter_foreground_task/service/EngineListener.kt
+++ b/android/src/main/kotlin/com/pravera/flutter_foreground_task/service/EngineListener.kt
@@ -1,0 +1,7 @@
+package com.pravera.flutter_foreground_task.service
+
+import io.flutter.embedding.engine.FlutterEngine
+
+interface EngineListener {
+  fun onEngineStarted(flutterEngine: FlutterEngine)
+}

--- a/android/src/main/kotlin/com/pravera/flutter_foreground_task/service/ForegroundService.kt
+++ b/android/src/main/kotlin/com/pravera/flutter_foreground_task/service/ForegroundService.kt
@@ -317,6 +317,7 @@ class ForegroundService : Service(), MethodChannel.MethodCallHandler {
 			if (iconBackgroundColor != null) {
 				builder.setColor(iconBackgroundColor)
 			}
+			builder.setContentIntent(getPendingIntent(pm))
 			builder.setContentTitle(notificationOptions.contentTitle)
 			builder.setContentText(notificationOptions.contentText)
 			val actions = buildButtonActions(true).toTypedArray()

--- a/android/src/main/kotlin/com/pravera/flutter_foreground_task/service/ForegroundService.kt
+++ b/android/src/main/kotlin/com/pravera/flutter_foreground_task/service/ForegroundService.kt
@@ -319,7 +319,7 @@ class ForegroundService : Service(), MethodChannel.MethodCallHandler {
 			}
 			builder.setContentTitle(notificationOptions.contentTitle)
 			builder.setContentText(notificationOptions.contentText)
-			val actions = buildButtonActions().toTypedArray()
+			val actions = buildButtonActions(true).toTypedArray()
 			builder.setActions(*actions)
 			nm.notify(notificationOptions.id, builder.build())
 		}
@@ -557,18 +557,19 @@ class ForegroundService : Service(), MethodChannel.MethodCallHandler {
 	}
 
 	@SuppressLint("UnspecifiedImmutableFlag")
-    private fun buildButtonActions(): List<Notification.Action> {
+    private fun buildButtonActions(update: Boolean = false): List<Notification.Action> {
 		val actions = mutableListOf<Notification.Action>()
 		val buttons = notificationOptions.buttons
 		for (i in buttons.indices) {
 			val bIntent = Intent(ACTION_NOTIFICATION_BUTTON_PRESSED).apply {
 				putExtra(DATA_FIELD_NAME, buttons[i].id)
 			}
-			val bPendingIntent = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-				PendingIntent.getBroadcast(this, i + 1, bIntent, PendingIntent.FLAG_IMMUTABLE)
-			} else {
-				PendingIntent.getBroadcast(this, i + 1, bIntent, 0)
-			}
+			var flag = 0
+			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M)
+				flag = flag or PendingIntent.FLAG_IMMUTABLE
+			if (update)
+				flag = flag or PendingIntent.FLAG_CANCEL_CURRENT
+			val bPendingIntent = PendingIntent.getBroadcast(this, i + 1, bIntent, flag)
 			val bTextColor = buttons[i].textColorRgb?.let(::getRgbColor)
 			val bText = getTextSpan(buttons[i].text, bTextColor)
 			val bAction = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
@@ -583,18 +584,19 @@ class ForegroundService : Service(), MethodChannel.MethodCallHandler {
 	}
 
 	@SuppressLint("UnspecifiedImmutableFlag")
-    private fun buildButtonCompatActions(): List<NotificationCompat.Action> {
+    private fun buildButtonCompatActions(update: Boolean = false): List<NotificationCompat.Action> {
 		val actions = mutableListOf<NotificationCompat.Action>()
 		val buttons = notificationOptions.buttons
 		for (i in buttons.indices) {
 			val bIntent = Intent(ACTION_NOTIFICATION_BUTTON_PRESSED).apply {
 				putExtra(DATA_FIELD_NAME, buttons[i].id)
 			}
-			val bPendingIntent = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-				PendingIntent.getBroadcast(this, i + 1, bIntent, PendingIntent.FLAG_IMMUTABLE)
-			} else {
-				PendingIntent.getBroadcast(this, i + 1, bIntent, 0)
-			}
+			var flag = 0
+			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M)
+				flag = flag or PendingIntent.FLAG_IMMUTABLE
+			if (update)
+				flag = flag or PendingIntent.FLAG_CANCEL_CURRENT
+			val bPendingIntent = PendingIntent.getBroadcast(this, i + 1, bIntent, flag)
 			val bTextColor = buttons[i].textColorRgb?.let(::getRgbColor)
 			val bText = getTextSpan(buttons[i].text, bTextColor)
 			val bAction = NotificationCompat.Action.Builder(0, bText, bPendingIntent).build()

--- a/android/src/main/kotlin/com/pravera/flutter_foreground_task/service/ForegroundService.kt
+++ b/android/src/main/kotlin/com/pravera/flutter_foreground_task/service/ForegroundService.kt
@@ -42,10 +42,15 @@ class ForegroundService : Service(), MethodChannel.MethodCallHandler {
         private const val ACTION_NOTIFICATION_PRESSED = "onNotificationPressed"
         private const val ACTION_MESSAGE_RECEIVED = "onReceivedMessage"
         private const val DATA_FIELD_NAME = "data"
+        private var engineListener : EngineListener? = null
 
 		/** Returns whether the foreground service is running. */
 		var isRunningService = false
 			private set
+
+		fun setEngineListener(listener: EngineListener?) {
+			engineListener = listener
+		}
 	}
 
 	private lateinit var foregroundServiceStatus: ForegroundServiceStatus
@@ -406,6 +411,7 @@ class ForegroundService : Service(), MethodChannel.MethodCallHandler {
 		}
 
 		currFlutterEngine = FlutterEngine(this)
+		engineListener?.onEngineStarted(currFlutterEngine!!)
 
 		currFlutterLoader = FlutterInjector.instance().flutterLoader()
 		if (currFlutterLoader?.initialized() == false) {

--- a/android/src/main/kotlin/com/pravera/flutter_foreground_task/service/ForegroundService.kt
+++ b/android/src/main/kotlin/com/pravera/flutter_foreground_task/service/ForegroundService.kt
@@ -40,6 +40,7 @@ class ForegroundService : Service(), MethodChannel.MethodCallHandler {
         private const val ACTION_TASK_DESTROY = "onDestroy"
         private const val ACTION_NOTIFICATION_BUTTON_PRESSED = "onNotificationButtonPressed"
         private const val ACTION_NOTIFICATION_PRESSED = "onNotificationPressed"
+        private const val ACTION_MESSAGE_RECEIVED = "onReceivedMessage"
         private const val DATA_FIELD_NAME = "data"
 
 		/** Returns whether the foreground service is running. */
@@ -156,6 +157,7 @@ class ForegroundService : Service(), MethodChannel.MethodCallHandler {
 		when (call.method) {
 			"initialize" -> startForegroundTask()
 			"notification" -> notifyService(call)
+			"sendMessage" -> handleSendMessage(call)
 			else -> result.notImplemented()
 		}
 	}
@@ -318,6 +320,12 @@ class ForegroundService : Service(), MethodChannel.MethodCallHandler {
 		}
 
 		isRunningService = true
+	}
+
+	private fun handleSendMessage(call: MethodCall) {
+		// Received a message from the main isolate. Pass it on to the task handler.
+		val argsMap = call.arguments as? Map<*, *>
+		backgroundChannel?.invokeMethod(ACTION_MESSAGE_RECEIVED, argsMap)
 	}
 
 	@SuppressLint("WakelockTimeout")

--- a/android/src/main/kotlin/com/pravera/flutter_foreground_task/service/ForegroundServiceManager.kt
+++ b/android/src/main/kotlin/com/pravera/flutter_foreground_task/service/ForegroundServiceManager.kt
@@ -97,6 +97,47 @@ class ForegroundServiceManager {
 		return true
 	}
 
+	/**
+	 * Notify the foreground service.
+	 *
+	 * @param context context
+	 * @param arguments arguments
+	 */
+	fun notify(context: Context, arguments: Any?): Boolean {
+		try {
+			val nIntent = Intent(context, ForegroundService::class.java)
+			val argsMap = arguments as? Map<*, *>
+			ForegroundServiceStatus.putData(context, ForegroundServiceAction.NOTIFY)
+			NotificationOptions.notificationContent(context, argsMap)
+			ContextCompat.startForegroundService(context, nIntent)
+		} catch (e: Exception) {
+			return false
+		}
+
+		return true
+	}
+
+	/**
+	 * Send message to the foreground service.
+	 *
+	 * @param context context
+	 * @param arguments arguments
+	 */
+	fun message(context: Context, arguments: Any?): Map<String, Any?> ?{
+		try {
+			val argsMap = arguments as? HashMap<String, Any?>
+			val nIntent = Intent(context, ForegroundService::class.java).apply {
+				putExtra("data", argsMap)
+			}
+			ForegroundServiceStatus.putData(context, ForegroundServiceAction.MESSAGE)
+			ContextCompat.startForegroundService(context, nIntent)
+		} catch (e: Exception) {
+			return null
+		}
+
+		return emptyMap()
+	}
+
 	/** Returns whether the foreground service is running. */
 	fun isRunningService(): Boolean = ForegroundService.isRunningService
 }

--- a/android/src/main/kotlin/com/pravera/flutter_foreground_task/service/ForegroundServiceManager.kt
+++ b/android/src/main/kotlin/com/pravera/flutter_foreground_task/service/ForegroundServiceManager.kt
@@ -123,7 +123,7 @@ class ForegroundServiceManager {
 	 * @param context context
 	 * @param arguments arguments
 	 */
-	fun message(context: Context, arguments: Any?): Map<String, Any?> ?{
+	fun message(context: Context, arguments: Any?): Boolean {
 		try {
 			val argsMap = arguments as? HashMap<String, Any?>
 			val nIntent = Intent(context, ForegroundService::class.java).apply {
@@ -132,10 +132,10 @@ class ForegroundServiceManager {
 			ForegroundServiceStatus.putData(context, ForegroundServiceAction.MESSAGE)
 			ContextCompat.startForegroundService(context, nIntent)
 		} catch (e: Exception) {
-			return null
+			return false
 		}
 
-		return emptyMap()
+		return true
 	}
 
 	/** Returns whether the foreground service is running. */

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -26,6 +26,6 @@ subprojects {
     project.evaluationDependsOn(':app')
 }
 
-task clean(type: Delete) {
+tasks.register("clean", Delete) {
     delete rootProject.buildDir
 }

--- a/lib/flutter_foreground_task.dart
+++ b/lib/flutter_foreground_task.dart
@@ -51,7 +51,7 @@ abstract class TaskHandler {
   void onNotificationPressed() => FlutterForegroundTask.launchApp();
 
   /// Called when a message is sent from the main program.
-  void onReceivedMessage(Map<String, dynamic> args) {}
+  void onReceivedMessage(dynamic args) {}
 }
 
 /// A class that implements foreground task and provides useful utilities.
@@ -133,7 +133,7 @@ class FlutterForegroundTask {
       );
 
   /// Sends a message to the foreground service.
-  static Future<Map<String, dynamic>?> sendMessage(
+  static Future<bool> sendMessage(
       Map<String, dynamic> message) =>
       FlutterForegroundTaskPlatform.instance.sendMessage(message);
 

--- a/lib/flutter_foreground_task.dart
+++ b/lib/flutter_foreground_task.dart
@@ -60,7 +60,6 @@ class FlutterForegroundTask {
   static late IOSNotificationOptions _iosNotificationOptions;
   static late ForegroundTaskOptions _foregroundTaskOptions;
   static bool _initialized = false;
-  static MethodChannel? backgroundChannel;
 
   /// Initialize the [FlutterForegroundTask].
   static void init({
@@ -81,7 +80,8 @@ class FlutterForegroundTask {
     Function? callback,
   }) {
     if (_initialized == false) {
-      throw const ForegroundTaskException('Not initialized. Please call this function after calling the init function.');
+      throw const ForegroundTaskException(
+          'Not initialized. Please call this function after calling the init function.');
     }
 
     return FlutterForegroundTaskPlatform.instance.startService(
@@ -95,7 +95,8 @@ class FlutterForegroundTask {
   }
 
   /// Restart the foreground service.
-  static Future<bool> restartService() => FlutterForegroundTaskPlatform.instance.restartService();
+  static Future<bool> restartService() =>
+      FlutterForegroundTaskPlatform.instance.restartService();
 
   /// Update the foreground service.
   static Future<bool> updateService({
@@ -112,7 +113,8 @@ class FlutterForegroundTask {
       );
 
   /// Stop the foreground service.
-  static Future<bool> stopService() => FlutterForegroundTaskPlatform.instance.stopService();
+  static Future<bool> stopService() =>
+      FlutterForegroundTaskPlatform.instance.stopService();
 
   /// Notifies the foreground service.
   static Future<bool> notification({
@@ -121,27 +123,23 @@ class FlutterForegroundTask {
     String? notificationText,
     NotificationIconData? iconData,
     List<NotificationButton>? buttons,
-  }) async {
-    final options = <String, dynamic>{
-      'notificationId': notificationId,
-      'notificationContentTitle': notificationTitle,
-      'notificationContentText': notificationText,
-      'iconData': iconData?.toJson(),
-      'buttons': buttons?.map((e) => e.toJson()).toList(),
-    };
-
-    // Notifies the foreground service.
-    await backgroundChannel!.invokeMethod('notification', options);
-    return true;
-  }
+  }) =>
+      FlutterForegroundTaskPlatform.instance.notification(
+        notificationId: notificationId,
+        notificationTitle: notificationTitle,
+        notificationText: notificationText,
+        iconData: iconData,
+        buttons: buttons,
+      );
 
   /// Sends a message to the foreground service.
-  static Future<Map<String, dynamic>?> sendMessage(Map<String, dynamic> message) async {
-    return backgroundChannel!.invokeMapMethod<String, dynamic>('sendMessage', message);
-  }
+  static Future<Map<String, dynamic>?> sendMessage(
+      Map<String, dynamic> message) =>
+      FlutterForegroundTaskPlatform.instance.sendMessage(message);
 
   /// Returns whether the foreground service is running.
-  static Future<bool> get isRunningService => FlutterForegroundTaskPlatform.instance.isRunningService;
+  static Future<bool> get isRunningService =>
+      FlutterForegroundTaskPlatform.instance.isRunningService;
 
   /// Get the [ReceivePort].
   static ReceivePort? get receivePort => _registerPort();
@@ -215,60 +213,76 @@ class FlutterForegroundTask {
   }
 
   /// Minimize the app to the background.
-  static void minimizeApp() => FlutterForegroundTaskPlatform.instance.minimizeApp();
+  static void minimizeApp() =>
+      FlutterForegroundTaskPlatform.instance.minimizeApp();
 
   /// Launch the app at [route] if it is not running otherwise open it.
-  static void launchApp([String? route]) => FlutterForegroundTaskPlatform.instance.launchApp(route);
+  static void launchApp([String? route]) =>
+      FlutterForegroundTaskPlatform.instance.launchApp(route);
 
   /// Toggles lockScreen visibility
-  static void setOnLockScreenVisibility(bool isVisible) => FlutterForegroundTaskPlatform.instance.setOnLockScreenVisibility(isVisible);
+  static void setOnLockScreenVisibility(bool isVisible) =>
+      FlutterForegroundTaskPlatform.instance
+          .setOnLockScreenVisibility(isVisible);
 
   /// Returns whether the app is in the foreground.
-  static Future<bool> get isAppOnForeground => FlutterForegroundTaskPlatform.instance.isAppOnForeground;
+  static Future<bool> get isAppOnForeground =>
+      FlutterForegroundTaskPlatform.instance.isAppOnForeground;
 
   /// Wake up the screen of a device that is turned off.
-  static void wakeUpScreen() => FlutterForegroundTaskPlatform.instance.wakeUpScreen();
+  static void wakeUpScreen() =>
+      FlutterForegroundTaskPlatform.instance.wakeUpScreen();
 
   /// Returns whether the app has been excluded from battery optimization.
-  static Future<bool> get isIgnoringBatteryOptimizations => FlutterForegroundTaskPlatform.instance.isIgnoringBatteryOptimizations;
+  static Future<bool> get isIgnoringBatteryOptimizations =>
+      FlutterForegroundTaskPlatform.instance.isIgnoringBatteryOptimizations;
 
   /// Open the settings page where you can set ignore battery optimization.
-  static Future<bool> openIgnoreBatteryOptimizationSettings() => FlutterForegroundTaskPlatform.instance.openIgnoreBatteryOptimizationSettings();
+  static Future<bool> openIgnoreBatteryOptimizationSettings() =>
+      FlutterForegroundTaskPlatform.instance
+          .openIgnoreBatteryOptimizationSettings();
 
   /// Request to ignore battery optimization.
-  static Future<bool> requestIgnoreBatteryOptimization() => FlutterForegroundTaskPlatform.instance.requestIgnoreBatteryOptimization();
+  static Future<bool> requestIgnoreBatteryOptimization() =>
+      FlutterForegroundTaskPlatform.instance.requestIgnoreBatteryOptimization();
 
   /// Returns whether the "android.permission.SYSTEM_ALERT_WINDOW" permission was granted.
-  static Future<bool> get canDrawOverlays => FlutterForegroundTaskPlatform.instance.canDrawOverlays;
+  static Future<bool> get canDrawOverlays =>
+      FlutterForegroundTaskPlatform.instance.canDrawOverlays;
 
   /// Open the settings page where you can allow/deny the "android.permission.SYSTEM_ALERT_WINDOW" permission.
   ///
   /// Pass the `forceOpen` bool to open the permissions page even if granted.
-  static Future<bool> openSystemAlertWindowSettings({bool forceOpen = false}) => FlutterForegroundTaskPlatform.instance.openSystemAlertWindowSettings(forceOpen: forceOpen);
+  static Future<bool> openSystemAlertWindowSettings({bool forceOpen = false}) =>
+      FlutterForegroundTaskPlatform.instance
+          .openSystemAlertWindowSettings(forceOpen: forceOpen);
 
   /// Returns "android.permission.POST_NOTIFICATIONS" permission status.
   ///
   /// for Android 13, https://developer.android.com/develop/ui/views/notifications/notification-permission
-  static Future<NotificationPermission> checkNotificationPermission() => FlutterForegroundTaskPlatform.instance.checkNotificationPermission();
+  static Future<NotificationPermission> checkNotificationPermission() =>
+      FlutterForegroundTaskPlatform.instance.checkNotificationPermission();
 
   /// Request "android.permission.POST_NOTIFICATIONS" permission.
   ///
   /// for Android 13, https://developer.android.com/develop/ui/views/notifications/notification-permission
-  static Future<NotificationPermission> requestNotificationPermission() => FlutterForegroundTaskPlatform.instance.requestNotificationPermission();
+  static Future<NotificationPermission> requestNotificationPermission() =>
+      FlutterForegroundTaskPlatform.instance.requestNotificationPermission();
 
   /// Set up the task handler and start the foreground task.
   ///
   /// It must always be called from a top-level function, otherwise foreground task will not work.
   static void setTaskHandler(TaskHandler handler) {
     // Create a method channel to communicate with the platform.
-    backgroundChannel = const MethodChannel('flutter_foreground_task/background');
+    const backgroundChannel =
+        MethodChannel('flutter_foreground_task/background');
 
     // Binding the framework to the flutter engine.
     WidgetsFlutterBinding.ensureInitialized();
     DartPluginRegistrant.ensureInitialized();
 
     // Set the method call handler for the background channel.
-    backgroundChannel!.setMethodCallHandler((call) async {
+    backgroundChannel.setMethodCallHandler((call) async {
       await (await SharedPreferences.getInstance()).reload();
       final timestamp = DateTime.now();
       final sendPort = _lookupPort();
@@ -297,7 +311,7 @@ class FlutterForegroundTask {
     });
 
     // Initializes the plug-in background channel and starts a foreground task.
-    backgroundChannel!.invokeMethod('initialize');
+    backgroundChannel.invokeMethod('initialize');
   }
 
   static ReceivePort? _registerPort() {

--- a/lib/flutter_foreground_task.dart
+++ b/lib/flutter_foreground_task.dart
@@ -49,6 +49,9 @@ abstract class TaskHandler {
   /// "android.permission.SYSTEM_ALERT_WINDOW" permission must be granted for
   /// this function to be called.
   void onNotificationPressed() => FlutterForegroundTask.launchApp();
+
+  /// Called when a message is sent from the main program.
+  void onReceivedMessage(Map<String, dynamic> args) {}
 }
 
 /// A class that implements foreground task and provides useful utilities.
@@ -57,7 +60,7 @@ class FlutterForegroundTask {
   static late IOSNotificationOptions _iosNotificationOptions;
   static late ForegroundTaskOptions _foregroundTaskOptions;
   static bool _initialized = false;
-  static late MethodChannel backgroundChannel;
+  static MethodChannel? backgroundChannel;
 
   /// Initialize the [FlutterForegroundTask].
   static void init({
@@ -78,8 +81,7 @@ class FlutterForegroundTask {
     Function? callback,
   }) {
     if (_initialized == false) {
-      throw const ForegroundTaskException(
-          'Not initialized. Please call this function after calling the init function.');
+      throw const ForegroundTaskException('Not initialized. Please call this function after calling the init function.');
     }
 
     return FlutterForegroundTaskPlatform.instance.startService(
@@ -93,8 +95,7 @@ class FlutterForegroundTask {
   }
 
   /// Restart the foreground service.
-  static Future<bool> restartService() =>
-      FlutterForegroundTaskPlatform.instance.restartService();
+  static Future<bool> restartService() => FlutterForegroundTaskPlatform.instance.restartService();
 
   /// Update the foreground service.
   static Future<bool> updateService({
@@ -111,8 +112,7 @@ class FlutterForegroundTask {
       );
 
   /// Stop the foreground service.
-  static Future<bool> stopService() =>
-      FlutterForegroundTaskPlatform.instance.stopService();
+  static Future<bool> stopService() => FlutterForegroundTaskPlatform.instance.stopService();
 
   /// Notifies the foreground service.
   static Future<bool> notification({
@@ -130,14 +130,18 @@ class FlutterForegroundTask {
       'buttons': buttons?.map((e) => e.toJson()).toList(),
     };
 
-    // Notifies the foreground task.
-    await backgroundChannel.invokeMethod('notification', options);
+    // Notifies the foreground service.
+    await backgroundChannel!.invokeMethod('notification', options);
     return true;
   }
 
+  /// Sends a message to the foreground service.
+  static Future<Map<String, dynamic>?> sendMessage(Map<String, dynamic> message) async {
+    return backgroundChannel!.invokeMapMethod<String, dynamic>('sendMessage', message);
+  }
+
   /// Returns whether the foreground service is running.
-  static Future<bool> get isRunningService =>
-      FlutterForegroundTaskPlatform.instance.isRunningService;
+  static Future<bool> get isRunningService => FlutterForegroundTaskPlatform.instance.isRunningService;
 
   /// Get the [ReceivePort].
   static ReceivePort? get receivePort => _registerPort();
@@ -211,76 +215,60 @@ class FlutterForegroundTask {
   }
 
   /// Minimize the app to the background.
-  static void minimizeApp() =>
-      FlutterForegroundTaskPlatform.instance.minimizeApp();
+  static void minimizeApp() => FlutterForegroundTaskPlatform.instance.minimizeApp();
 
   /// Launch the app at [route] if it is not running otherwise open it.
-  static void launchApp([String? route]) =>
-      FlutterForegroundTaskPlatform.instance.launchApp(route);
+  static void launchApp([String? route]) => FlutterForegroundTaskPlatform.instance.launchApp(route);
 
   /// Toggles lockScreen visibility
-  static void setOnLockScreenVisibility(bool isVisible) =>
-      FlutterForegroundTaskPlatform.instance
-          .setOnLockScreenVisibility(isVisible);
+  static void setOnLockScreenVisibility(bool isVisible) => FlutterForegroundTaskPlatform.instance.setOnLockScreenVisibility(isVisible);
 
   /// Returns whether the app is in the foreground.
-  static Future<bool> get isAppOnForeground =>
-      FlutterForegroundTaskPlatform.instance.isAppOnForeground;
+  static Future<bool> get isAppOnForeground => FlutterForegroundTaskPlatform.instance.isAppOnForeground;
 
   /// Wake up the screen of a device that is turned off.
-  static void wakeUpScreen() =>
-      FlutterForegroundTaskPlatform.instance.wakeUpScreen();
+  static void wakeUpScreen() => FlutterForegroundTaskPlatform.instance.wakeUpScreen();
 
   /// Returns whether the app has been excluded from battery optimization.
-  static Future<bool> get isIgnoringBatteryOptimizations =>
-      FlutterForegroundTaskPlatform.instance.isIgnoringBatteryOptimizations;
+  static Future<bool> get isIgnoringBatteryOptimizations => FlutterForegroundTaskPlatform.instance.isIgnoringBatteryOptimizations;
 
   /// Open the settings page where you can set ignore battery optimization.
-  static Future<bool> openIgnoreBatteryOptimizationSettings() =>
-      FlutterForegroundTaskPlatform.instance
-          .openIgnoreBatteryOptimizationSettings();
+  static Future<bool> openIgnoreBatteryOptimizationSettings() => FlutterForegroundTaskPlatform.instance.openIgnoreBatteryOptimizationSettings();
 
   /// Request to ignore battery optimization.
-  static Future<bool> requestIgnoreBatteryOptimization() =>
-      FlutterForegroundTaskPlatform.instance.requestIgnoreBatteryOptimization();
+  static Future<bool> requestIgnoreBatteryOptimization() => FlutterForegroundTaskPlatform.instance.requestIgnoreBatteryOptimization();
 
   /// Returns whether the "android.permission.SYSTEM_ALERT_WINDOW" permission was granted.
-  static Future<bool> get canDrawOverlays =>
-      FlutterForegroundTaskPlatform.instance.canDrawOverlays;
+  static Future<bool> get canDrawOverlays => FlutterForegroundTaskPlatform.instance.canDrawOverlays;
 
   /// Open the settings page where you can allow/deny the "android.permission.SYSTEM_ALERT_WINDOW" permission.
   ///
   /// Pass the `forceOpen` bool to open the permissions page even if granted.
-  static Future<bool> openSystemAlertWindowSettings({bool forceOpen = false}) =>
-      FlutterForegroundTaskPlatform.instance
-          .openSystemAlertWindowSettings(forceOpen: forceOpen);
+  static Future<bool> openSystemAlertWindowSettings({bool forceOpen = false}) => FlutterForegroundTaskPlatform.instance.openSystemAlertWindowSettings(forceOpen: forceOpen);
 
   /// Returns "android.permission.POST_NOTIFICATIONS" permission status.
   ///
   /// for Android 13, https://developer.android.com/develop/ui/views/notifications/notification-permission
-  static Future<NotificationPermission> checkNotificationPermission() =>
-      FlutterForegroundTaskPlatform.instance.checkNotificationPermission();
+  static Future<NotificationPermission> checkNotificationPermission() => FlutterForegroundTaskPlatform.instance.checkNotificationPermission();
 
   /// Request "android.permission.POST_NOTIFICATIONS" permission.
   ///
   /// for Android 13, https://developer.android.com/develop/ui/views/notifications/notification-permission
-  static Future<NotificationPermission> requestNotificationPermission() =>
-      FlutterForegroundTaskPlatform.instance.requestNotificationPermission();
+  static Future<NotificationPermission> requestNotificationPermission() => FlutterForegroundTaskPlatform.instance.requestNotificationPermission();
 
   /// Set up the task handler and start the foreground task.
   ///
   /// It must always be called from a top-level function, otherwise foreground task will not work.
   static void setTaskHandler(TaskHandler handler) {
     // Create a method channel to communicate with the platform.
-    backgroundChannel =
-        const MethodChannel('flutter_foreground_task/background');
+    backgroundChannel = const MethodChannel('flutter_foreground_task/background');
 
     // Binding the framework to the flutter engine.
     WidgetsFlutterBinding.ensureInitialized();
     DartPluginRegistrant.ensureInitialized();
 
     // Set the method call handler for the background channel.
-    backgroundChannel.setMethodCallHandler((call) async {
+    backgroundChannel!.setMethodCallHandler((call) async {
       await (await SharedPreferences.getInstance()).reload();
       final timestamp = DateTime.now();
       final sendPort = _lookupPort();
@@ -301,11 +289,15 @@ class FlutterForegroundTask {
           break;
         case 'onNotificationPressed':
           handler.onNotificationPressed();
+          break;
+        case 'onReceivedMessage':
+          handler.onReceivedMessage(call.arguments);
+          break;
       }
     });
 
     // Initializes the plug-in background channel and starts a foreground task.
-    backgroundChannel.invokeMethod('initialize');
+    backgroundChannel!.invokeMethod('initialize');
   }
 
   static ReceivePort? _registerPort() {

--- a/lib/flutter_foreground_task_method_channel.dart
+++ b/lib/flutter_foreground_task_method_channel.dart
@@ -164,13 +164,13 @@ class MethodChannelFlutterForegroundTask extends FlutterForegroundTaskPlatform {
   }
 
   @override
-  Future<Map<String, dynamic>?> sendMessage(
+  Future<bool> sendMessage(
     Map<String, dynamic> message,
   ) async {
     if (await isRunningService) {
-      return await methodChannel.invokeMapMethod<String, dynamic>('sendMessage', message);
+      return await methodChannel.invokeMethod('sendMessage', message);
     }
-    return null;
+    return false;
   }
 
   @override

--- a/lib/flutter_foreground_task_method_channel.dart
+++ b/lib/flutter_foreground_task_method_channel.dart
@@ -4,6 +4,8 @@ import 'dart:ui';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_foreground_task/models/notification_button.dart';
+import 'package:flutter_foreground_task/models/notification_icon_data.dart';
 
 import 'flutter_foreground_task_platform_interface.dart';
 import 'models/android_notification_options.dart';
@@ -138,6 +140,37 @@ class MethodChannelFlutterForegroundTask extends FlutterForegroundTaskPlatform {
     });
 
     return stopState;
+  }
+
+  @override
+  Future<bool> notification({
+    required int notificationId,
+    String? notificationTitle,
+    String? notificationText,
+    NotificationIconData? iconData,
+    List<NotificationButton>? buttons,
+  }) async {
+    if (await isRunningService) {
+      final options = <String, dynamic>{
+        'notificationId': notificationId,
+        'notificationContentTitle': notificationTitle,
+        'notificationContentText': notificationText,
+        'iconData': iconData?.toJson(),
+        'buttons': buttons?.map((e) => e.toJson()).toList(),
+      };
+      return await methodChannel.invokeMethod('notification', options);
+    }
+    return false;
+  }
+
+  @override
+  Future<Map<String, dynamic>?> sendMessage(
+    Map<String, dynamic> message,
+  ) async {
+    if (await isRunningService) {
+      return await methodChannel.invokeMapMethod<String, dynamic>('sendMessage', message);
+    }
+    return null;
   }
 
   @override

--- a/lib/flutter_foreground_task_platform_interface.dart
+++ b/lib/flutter_foreground_task_platform_interface.dart
@@ -1,3 +1,5 @@
+import 'package:flutter_foreground_task/models/notification_button.dart';
+import 'package:flutter_foreground_task/models/notification_icon_data.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
 import 'flutter_foreground_task_method_channel.dart';
@@ -54,6 +56,20 @@ abstract class FlutterForegroundTaskPlatform extends PlatformInterface {
 
   Future<bool> stopService() {
     throw UnimplementedError('stopService() has not been implemented.');
+  }
+
+  Future<bool> notification({
+    required int notificationId,
+    String? notificationTitle,
+    String? notificationText,
+    NotificationIconData? iconData,
+    List<NotificationButton>? buttons,
+  }) {
+    throw UnimplementedError('notification() has not been implemented.');
+  }
+
+  Future<Map<String, dynamic>?> sendMessage(Map<String, dynamic> message) {
+    throw UnimplementedError('sendMessage() has not been implemented.');
   }
 
   Future<bool> get isRunningService {

--- a/lib/flutter_foreground_task_platform_interface.dart
+++ b/lib/flutter_foreground_task_platform_interface.dart
@@ -68,7 +68,7 @@ abstract class FlutterForegroundTaskPlatform extends PlatformInterface {
     throw UnimplementedError('notification() has not been implemented.');
   }
 
-  Future<Map<String, dynamic>?> sendMessage(Map<String, dynamic> message) {
+  Future<bool> sendMessage(Map<String, dynamic> message) {
     throw UnimplementedError('sendMessage() has not been implemented.');
   }
 


### PR DESCRIPTION
Despite of what I wrote in #183, I needed to tap into the plugin because I needed to call the notification from the task handler callback and that doesn't work from a foreign plugin. :-)

The whole thing is conditional on API 26 and there's no equivalent in `NotificationCompat`, unfortunately. I don't know what the real solution would be, just to emit a log message or what...