### PR TITLE
On Android 14+, allow for the subset of declared permissions to be specified at the time of launching the service

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.2'
+        classpath 'com.android.tools.build:gradle:7.4.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -49,4 +49,5 @@ dependencies {
     // implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4'
+    implementation 'androidx.core:core:1.12.0'
 }

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.pravera.flutter_foreground_task">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.pravera.flutter_foreground_task">
 
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />

--- a/android/src/main/kotlin/com/pravera/flutter_foreground_task/PreferencesKey.kt
+++ b/android/src/main/kotlin/com/pravera/flutter_foreground_task/PreferencesKey.kt
@@ -30,6 +30,7 @@ object PreferencesKey {
     const val VISIBILITY = "visibility"
     const val ICON_DATA = "iconData"
     const val BUTTONS = "buttons"
+    const val PERMISSION_TYPES = "permissionTypes"
 
     const val FOREGROUND_TASK_OPTIONS_PREFS = prefix + "FOREGROUND_TASK_OPTIONS"
     const val TASK_INTERVAL = "interval"

--- a/android/src/main/kotlin/com/pravera/flutter_foreground_task/models/NotificationOptions.kt
+++ b/android/src/main/kotlin/com/pravera/flutter_foreground_task/models/NotificationOptions.kt
@@ -139,7 +139,7 @@ data class NotificationOptions(
                 putInt(PrefsKey.VISIBILITY, visibility)
                 putString(PrefsKey.ICON_DATA, iconDataJson)
                 putString(PrefsKey.BUTTONS, buttonsJson)
-                pintInt(PrefsKey.PERMISSION_TYPES, permissionTypes)
+                putInt(PrefsKey.PERMISSION_TYPES, permissionTypes)
                 commit()
             }
         }

--- a/android/src/main/kotlin/com/pravera/flutter_foreground_task/models/NotificationOptions.kt
+++ b/android/src/main/kotlin/com/pravera/flutter_foreground_task/models/NotificationOptions.kt
@@ -18,6 +18,7 @@ data class NotificationOptions(
     val playSound: Boolean,
     val showWhen: Boolean,
     val isSticky: Boolean,
+    val permissionTypes: Int,
     val visibility: Int,
     val iconData: NotificationIconData?,
     val buttons: List<NotificationButton>
@@ -28,6 +29,7 @@ data class NotificationOptions(
                 PrefsKey.NOTIFICATION_OPTIONS_PREFS, Context.MODE_PRIVATE)
 
             val id = prefs.getInt(PrefsKey.NOTIFICATION_ID, 1000)
+            val permissionTypes = prefs.getInt(PrefsKey.PERMISSION_TYPES, 0)
             val channelId = prefs.getString(PrefsKey.NOTIFICATION_CHANNEL_ID, null) ?: "foreground_service"
             val channelName = prefs.getString(PrefsKey.NOTIFICATION_CHANNEL_NAME, null) ?: "Foreground Service"
             val channelDesc = prefs.getString(PrefsKey.NOTIFICATION_CHANNEL_DESC, null)
@@ -84,7 +86,8 @@ data class NotificationOptions(
                 isSticky = isSticky,
                 visibility = visibility,
                 iconData = iconData,
-                buttons = buttons
+                buttons = buttons,
+                permissionTypes = permissionTypes
             )
         }
 
@@ -118,6 +121,8 @@ data class NotificationOptions(
                 buttonsJson = JSONArray(buttons).toString()
             }
 
+            val permissionTypes = map?.get(PrefsKey.PERMISSION_TYPES) as? Int ?: 0
+
             with(prefs.edit()) {
                 putInt(PrefsKey.NOTIFICATION_ID, id)
                 putString(PrefsKey.NOTIFICATION_CHANNEL_ID, channelId)
@@ -134,6 +139,7 @@ data class NotificationOptions(
                 putInt(PrefsKey.VISIBILITY, visibility)
                 putString(PrefsKey.ICON_DATA, iconDataJson)
                 putString(PrefsKey.BUTTONS, buttonsJson)
+                pintInt(PrefsKey.PERMISSION_TYPES, permissionTypes)
                 commit()
             }
         }

--- a/android/src/main/kotlin/com/pravera/flutter_foreground_task/service/ForegroundService.kt
+++ b/android/src/main/kotlin/com/pravera/flutter_foreground_task/service/ForegroundService.kt
@@ -12,7 +12,9 @@ import android.text.Spannable
 import android.text.SpannableString
 import android.text.style.ForegroundColorSpan
 import android.util.Log
+import androidx.annotation.RequiresApi
 import androidx.core.app.NotificationCompat
+import androidx.core.app.ServiceCompat
 import com.pravera.flutter_foreground_task.models.*
 import com.pravera.flutter_foreground_task.utils.ForegroundServiceUtils
 import io.flutter.FlutterInjector
@@ -197,7 +199,7 @@ class ForegroundService : Service(), MethodChannel.MethodCallHandler {
 		val iconData = notificationOptions.iconData
 		val iconBackgroundColor: Int?
         val iconResId: Int
-        if (iconData != null) {
+		if (iconData != null) {
             iconBackgroundColor = iconData.backgroundColorRgb?.let(::getRgbColor)
             iconResId = getIconResIdFromIconData(iconData)
         } else {
@@ -241,7 +243,18 @@ class ForegroundService : Service(), MethodChannel.MethodCallHandler {
 			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
 				builder.setForegroundServiceBehavior(Notification.FOREGROUND_SERVICE_IMMEDIATE)
 			}
-			startForeground(notificationOptions.id, builder.build())
+
+			if(notificationOptions.permissionTypes > 0) {
+				ServiceCompat.startForeground(
+					this,
+					notificationOptions.id,
+					builder.build(),
+					notificationOptions.permissionTypes
+				)
+			} else {
+				startForeground(notificationOptions.id, builder.build())
+			}
+
 		} else {
 			val builder = NotificationCompat.Builder(this, channelId)
 			builder.setOngoing(true)

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 33
+    compileSdk 34
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
@@ -36,7 +36,7 @@ android {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.pravera.flutter_foreground_task_example"
         minSdkVersion 21
-        targetSdkVersion 33
+        targetSdkVersion 34
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }
@@ -56,6 +56,7 @@ android {
                     'proguard-rules.pro'
         }
     }
+    namespace 'com.pravera.flutter_foreground_task_example'
 }
 
 flutter {

--- a/example/android/app/src/debug/AndroidManifest.xml
+++ b/example/android/app/src/debug/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.pravera.flutter_foreground_task_example">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.pravera.flutter_foreground_task.example">
     <!-- Flutter needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.
     -->

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.pravera.flutter_foreground_task_example">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.pravera.flutter_foreground_task.example">
 
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />

--- a/example/android/app/src/profile/AndroidManifest.xml
+++ b/example/android/app/src/profile/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.pravera.flutter_foreground_task_example">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.pravera.flutter_foreground_task.example">
     <!-- Flutter needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.
     -->

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,12 +1,15 @@
+group 'com.pravera.flutter_foreground_task'
+version '1.0-SNAPSHOT'
+
 buildscript {
-    ext.kotlin_version = '1.6.10'
+    ext.kotlin_version = '1.7.10'
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.2'
+        classpath 'com.android.tools.build:gradle:7.3.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -18,14 +21,48 @@ allprojects {
     }
 }
 
-rootProject.buildDir = '../build'
-subprojects {
-    project.buildDir = "${rootProject.buildDir}/${project.name}"
-}
-subprojects {
-    project.evaluationDependsOn(':app')
-}
+apply plugin: 'com.android.library'
+apply plugin: 'kotlin-android'
 
-task clean(type: Delete) {
-    delete rootProject.buildDir
+android {
+
+        namespace 'com.pravera.flutter_foreground_task'
+
+
+    compileSdk 34
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
+
+    sourceSets {
+        main.java.srcDirs += 'src/main/kotlin'
+        test.java.srcDirs += 'src/test/kotlin'
+    }
+
+    defaultConfig {
+        minSdkVersion 19
+    }
+
+    dependencies {
+        testImplementation 'org.jetbrains.kotlin:kotlin-test'
+        testImplementation 'org.mockito:mockito-core:5.0.0'
+    }
+
+    testOptions {
+        unitTests.all {
+            useJUnitPlatform()
+
+            testLogging {
+                events "passed", "skipped", "failed", "standardOut", "standardError"
+                outputs.upToDateWhen {false}
+                showStandardStreams = true
+            }
+        }
+    }
 }

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.3-all.zip

--- a/lib/models/AndroidForegroundServiceType.dart
+++ b/lib/models/AndroidForegroundServiceType.dart
@@ -1,0 +1,19 @@
+class AndroidForegroundServiceType {
+  static const int CAMERA = 64;
+  static const int CONNECTED_DEVICE = 16;
+  static const int DATA_SYNC = 1;
+  static const int HEALTH = 256;
+  static const int LOCATION = 8;
+  static const int MANIFEST = -1;
+  static const int MEDIA_PLAYBACK = 2;
+  static const int MEDIA_PROJECTION = 32;
+  static const int MICROPHONE = 128;
+  static const int PHONE_CALL = 4;
+  static const int REMOTE_MESSAGING = 512;
+  static const int SHORT_SERVICE = 2048;
+  static const int SPECIAL_USE = 1073741824;
+  static const int SYSTEM_EXEMPTED = 1024;
+
+  // Private constructor to prevent instantiation.
+  AndroidForegroundServiceType._();
+}

--- a/lib/models/android_notification_options.dart
+++ b/lib/models/android_notification_options.dart
@@ -20,7 +20,7 @@ class AndroidNotificationOptions {
     this.showWhen = false,
     this.isSticky = true,
     this.visibility = NotificationVisibility.VISIBILITY_PUBLIC,
-    this.notificationTypes = 0,
+    this.permissionTypes = 0,
     this.iconData,
     this.buttons,
   })  : assert(channelId.isNotEmpty),
@@ -80,7 +80,7 @@ class AndroidNotificationOptions {
 
   /// An integer representing the permission types to be invoked
   /// This is the sum of the bitmap
-  final int notificationTypes;
+  final int permissionTypes;
 
   /// Returns the data fields of [AndroidNotificationOptions] in JSON format.
   Map<String, dynamic> toJson() {
@@ -98,6 +98,7 @@ class AndroidNotificationOptions {
       'visibility': visibility.rawValue,
       'iconData': iconData?.toJson(),
       'buttons': buttons?.map((e) => e.toJson()).toList(),
+      'permissionTypes': permissionTypes
     };
   }
 }

--- a/lib/models/android_notification_options.dart
+++ b/lib/models/android_notification_options.dart
@@ -6,6 +6,7 @@ import 'package:flutter_foreground_task/models/notification_visibility.dart';
 
 /// Notification options for Android platform.
 class AndroidNotificationOptions {
+
   /// Constructs an instance of [AndroidNotificationOptions].
   AndroidNotificationOptions({
     this.id,
@@ -19,6 +20,7 @@ class AndroidNotificationOptions {
     this.showWhen = false,
     this.isSticky = true,
     this.visibility = NotificationVisibility.VISIBILITY_PUBLIC,
+    this.notificationTypes = 0,
     this.iconData,
     this.buttons,
   })  : assert(channelId.isNotEmpty),
@@ -75,6 +77,10 @@ class AndroidNotificationOptions {
   /// A list of buttons to display in the notification.
   /// A maximum of 3 is allowed.
   final List<NotificationButton>? buttons;
+
+  /// An integer representing the permission types to be invoked
+  /// This is the sum of the bitmap
+  final int notificationTypes;
 
   /// Returns the data fields of [AndroidNotificationOptions] in JSON format.
   Map<String, dynamic> toJson() {


### PR DESCRIPTION
My use-case is as follows

- My app has an audio rooms feature
- (A) Some of my users only listen - they never accept the MICROPHONE permission and use the app as listeners
- (B) Some of my users speak and listen as well
- When the app is in the background, the permissions for the foreground task depend on which of the two they are
  - In case of (A) we need to launch the foreground task with a subset of the declared permissions (MEDIA_PLAYBACK)
  - In case of (B) we need to launch the foreground task with all MICROPHONE + MEDIA_PLAYBACK
- This requires a decision at run-time to determine which permissions to launch with
- If you launch the service with MICROPHONE permissions but the user has not accepted the MICROPHONE permission, you get a SecurityException (see below)

From the [relevant Android docs](https://developer.android.com/develop/background-work/services/foreground-services#wiu-restrictions-exemptions):

> Note: If an app that targets API level 28 or higher attempts to create a foreground service without requesting the FOREGROUND_SERVICE permission, the system throws a [SecurityException](https://developer.android.com/reference/java/lang/SecurityException). Similarly, if an app targets API level 34 or higher and doesn't request the appropriate specific permission, the system throws SecurityException.

and 

> Inside the service, usually in onStartCommand(), you can request that your service run in the foreground. To do so, call [ServiceCompat.startForeground()](https://developer.android.com/reference/androidx/core/app/ServiceCompat#startForeground(android.app.Service,int,android.app.Notification,int)) (available in androidx-core 1.12 and higher). This method takes the following parameters:
> 
> - The service
> - A positive integer that uniquely identifies the notification in the status bar
> - The [Notification](https://developer.android.com/reference/android/app/Notification) object itself
> - The [foreground service types](https://developer.android.com/develop/background-work/services/fg-service-types) identifying the work done by the service
>
> These types might be a subset of the [types declared in the manifest](https://developer.android.com/develop/background-work/services/foreground-services#types), depending on the specific use case. Then, if you need to add more service types, you can call startForeground() again.

These changes modify `AndroidNotificationOptions` to allow the developer to specify the bitmap sum of permissions with which the service will be launched (via `ServiceCompat.startForeground` as mentioned above). This also adds a class of constants [AndroidForegroundServiceType.dart](https://github.com/Dev-hwang/flutter_foreground_task/compare/master...fareesh:flutter_foreground_task:master#diff-ed514c04b60a2d3bb8cc61b9a61177aa3edd5fa09c881716f98b9dcacca12bb3) for the user to easily sum up the permissions they need:

e.g.

```dart
AndroidNotificationOptions(
   ...
   permissionTypes: AndroidForegroundServiceType.MICROPHONE + AndroidForegroundServiceType.MEDIA_PLAYBACK
)
```