### PR TITLE
chore : update readme 

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,17 @@ Change the type with your type (all types are listed in the link above).
 
 ```
 
+Additionally, when you declare your **AndroidNotificationOptions**, you need to specify the ***foregroundServiceType***.
+
+```dart
+androidNotificationOptions: AndroidNotificationOptions(
+              foregroundServiceType: AndroidForegroundServiceType.DATA_SYNC,
+              channelId: 'channelId',
+              channelName: 'channelName',
+              channelDescription: 'channelDescription',
+            ),
+```
+
 
 ### :baby_chick: iOS
 


### PR DESCRIPTION
This PR updates the readme file to clarify that you need to specify the **foregroundServiceType** inside **AndroidNotificationOptions**. Otherwise, the app will crash on Android 14 as mentioned here #220 .