### PR TITLE
release: 8.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 8.6.0
+
+* [**BREAKING**] Change the way to set the task intervals (for increase scalability)
+  - Remove `interval`, `isOnceEvent` option in ForegroundTaskOptions model
+  - Add `eventAction` option with ForegroundTaskEventAction constructor
+  - Check [migration_documentation](./documentation/migration_documentation.md) for changes
+
 ## 8.5.0
 
 * [**FEAT**] Add `openAlarmsAndRemindersSettings` utility

--- a/README.md
+++ b/README.md
@@ -4,10 +4,11 @@ This plugin is used to implement a foreground service on the Android platform.
 
 ## Features
 
-* Can perform repetitive tasks with foreground service.
-* Provides a widget that minimize the app without closing it when the user presses the soft back button.
+* Can perform repetitive tasks with the foreground service.
+* Supports two-way communication between the foreground service and UI.
+* Provides widget that minimize the app without closing it when the user presses the soft back button.
 * Provides useful utilities that can use while performing tasks.
-* Provides option to automatically resume foreground service on boot.
+* Provides option to automatically resume the foreground service on boot.
 
 ## Getting started
 
@@ -174,7 +175,10 @@ class MyTaskHandler extends TaskHandler {
     print('onStart');
   }
 
-  // Called every [ForegroundTaskOptions.interval] milliseconds.
+  // Called by eventAction in [ForegroundTaskOptions].
+  // - nothing() : Not use onRepeatEvent callback.
+  // - once() : Call onRepeatEvent only once.
+  // - repeat(interval) : Call onRepeatEvent at milliseconds interval.
   @override
   void onRepeatEvent(DateTime timestamp) {
     // Send data to main isolate.
@@ -314,9 +318,8 @@ Future<void> _initService() async {
       showNotification: true,
       playSound: false,
     ),
-    foregroundTaskOptions: const ForegroundTaskOptions(
-      interval: 5000,
-      isOnceEvent: false,
+    foregroundTaskOptions: ForegroundTaskOptions(
+      eventAction: ForegroundTaskEventAction.repeat(5000),
       autoRunOnBoot: true,
       autoRunOnMyPackageReplaced: true,
       allowWakeLock: true,
@@ -393,12 +396,14 @@ class FirstTaskHandler extends TaskHandler {
   void onRepeatEvent(DateTime timestamp) {
     if (_count == 10) {
       FlutterForegroundTask.updateService(
-        foregroundTaskOptions: const ForegroundTaskOptions(interval: 1000),
+        foregroundTaskOptions: ForegroundTaskOptions(
+          eventAction: ForegroundTaskEventAction.repeat(1000),
+        ),
         callback: updateCallback,
       );
     } else {
       FlutterForegroundTask.updateService(
-        notificationTitle: 'FirstTaskHandler',
+        notificationTitle: 'FirstTask',
         notificationText: timestamp.toString(),
       );
 
@@ -432,7 +437,7 @@ class SecondTaskHandler extends TaskHandler {
   @override
   void onRepeatEvent(DateTime timestamp) {
     FlutterForegroundTask.updateService(
-      notificationTitle: 'SecondTaskHandler',
+      notificationTitle: 'SecondTask',
       notificationText: timestamp.toString(),
     );
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ To use this plugin, add `flutter_foreground_task` as a [dependency in your pubsp
 
 ```yaml
 dependencies:
-  flutter_foreground_task: ^8.5.0
+  flutter_foreground_task: ^8.6.0
 ```
 
 After adding the `flutter_foreground_task` plugin to the flutter project, we need to specify the permissions and service to use for this plugin to work properly.

--- a/android/src/main/kotlin/com/pravera/flutter_foreground_task/FlutterForegroundTaskLifecycleListener.kt
+++ b/android/src/main/kotlin/com/pravera/flutter_foreground_task/FlutterForegroundTaskLifecycleListener.kt
@@ -15,7 +15,7 @@ interface FlutterForegroundTaskLifecycleListener {
     /** Called when the task is started. */
     fun onTaskStart()
 
-    /** Called every ForegroundTaskOptions.interval milliseconds. */
+    /** Called by eventAction in ForegroundTaskOptions. */
     fun onTaskRepeatEvent()
 
     /** Called when the task is destroyed. */

--- a/android/src/main/kotlin/com/pravera/flutter_foreground_task/PreferencesKey.kt
+++ b/android/src/main/kotlin/com/pravera/flutter_foreground_task/PreferencesKey.kt
@@ -34,8 +34,9 @@ object PreferencesKey {
     const val NOTIFICATION_CONTENT_BUTTONS = "buttons"
 
     const val FOREGROUND_TASK_OPTIONS_PREFS = prefix + "FOREGROUND_TASK_OPTIONS"
-    const val TASK_INTERVAL = "interval"
-    const val IS_ONCE_EVENT = "isOnceEvent"
+    const val TASK_EVENT_ACTION = "taskEventAction" // new
+    const val INTERVAL = "interval" // deprecated
+    const val IS_ONCE_EVENT = "isOnceEvent" // deprecated
     const val AUTO_RUN_ON_BOOT = "autoRunOnBoot"
     const val AUTO_RUN_ON_MY_PACKAGE_REPLACED = "autoRunOnMyPackageReplaced"
     const val ALLOW_WAKE_LOCK = "allowWakeLock"

--- a/android/src/main/kotlin/com/pravera/flutter_foreground_task/models/ForegroundTaskEventAction.kt
+++ b/android/src/main/kotlin/com/pravera/flutter_foreground_task/models/ForegroundTaskEventAction.kt
@@ -1,0 +1,45 @@
+package com.pravera.flutter_foreground_task.models
+
+import org.json.JSONObject
+import java.util.Objects
+
+data class ForegroundTaskEventAction(
+    val type: ForegroundTaskEventType,
+    val interval: Long
+) {
+    companion object {
+        private const val TASK_EVENT_TYPE_KEY = "taskEventType"
+        private const val TASK_EVENT_INTERVAL_KEY = "taskEventInterval"
+
+        fun fromJsonString(jsonString: String): ForegroundTaskEventAction {
+            val jsonObj = JSONObject(jsonString)
+
+            val type: ForegroundTaskEventType = if (jsonObj.isNull(TASK_EVENT_TYPE_KEY)) {
+                ForegroundTaskEventType.NOTHING
+            } else {
+                val value = jsonObj.getInt(TASK_EVENT_TYPE_KEY)
+                ForegroundTaskEventType.fromValue(value)
+            }
+
+            val interval: Long = if (jsonObj.isNull(TASK_EVENT_INTERVAL_KEY)) {
+                5000L
+            } else {
+                val value = jsonObj.getInt(TASK_EVENT_INTERVAL_KEY)
+                value.toLong()
+            }
+
+            return ForegroundTaskEventAction(type = type, interval = interval)
+        }
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (other == null || other !is ForegroundTaskEventAction) {
+            return false
+        }
+        return this.type.value == other.type.value && this.interval == other.interval
+    }
+
+    override fun hashCode(): Int {
+        return Objects.hash(type.value, interval)
+    }
+}

--- a/android/src/main/kotlin/com/pravera/flutter_foreground_task/models/ForegroundTaskEventType.kt
+++ b/android/src/main/kotlin/com/pravera/flutter_foreground_task/models/ForegroundTaskEventType.kt
@@ -1,0 +1,12 @@
+package com.pravera.flutter_foreground_task.models
+
+enum class ForegroundTaskEventType(val value: Int) {
+    NOTHING(1),
+    ONCE(2),
+    REPEAT(3);
+
+    companion object {
+        fun fromValue(value: Int) =
+            ForegroundTaskEventType.values().firstOrNull { it.value == value } ?: NOTHING
+    }
+}

--- a/android/src/main/kotlin/com/pravera/flutter_foreground_task/models/ForegroundTaskOptions.kt
+++ b/android/src/main/kotlin/com/pravera/flutter_foreground_task/models/ForegroundTaskOptions.kt
@@ -1,11 +1,11 @@
 package com.pravera.flutter_foreground_task.models
 
 import android.content.Context
+import org.json.JSONObject
 import com.pravera.flutter_foreground_task.PreferencesKey as PrefsKey
 
 data class ForegroundTaskOptions(
-    val interval: Long,
-    val isOnceEvent: Boolean,
+    val eventAction: ForegroundTaskEventAction,
     val autoRunOnBoot: Boolean,
     val autoRunOnMyPackageReplaced: Boolean,
     val allowWakeLock: Boolean,
@@ -16,16 +16,27 @@ data class ForegroundTaskOptions(
             val prefs = context.getSharedPreferences(
                 PrefsKey.FOREGROUND_TASK_OPTIONS_PREFS, Context.MODE_PRIVATE)
 
-            val interval = prefs.getLong(PrefsKey.TASK_INTERVAL, 5000L)
-            val isOnceEvent = prefs.getBoolean(PrefsKey.IS_ONCE_EVENT, false)
+            val eventActionJsonString = prefs.getString(PrefsKey.TASK_EVENT_ACTION, null)
+            val eventAction: ForegroundTaskEventAction = if (eventActionJsonString != null) {
+                ForegroundTaskEventAction.fromJsonString(eventActionJsonString)
+            } else {
+                // for deprecated api
+                val oldIsOnceEvent = prefs.getBoolean(PrefsKey.IS_ONCE_EVENT, false)
+                val oldInterval = prefs.getLong(PrefsKey.INTERVAL, 5000L)
+                if (oldIsOnceEvent) {
+                    ForegroundTaskEventAction(ForegroundTaskEventType.ONCE, oldInterval)
+                } else {
+                    ForegroundTaskEventAction(ForegroundTaskEventType.REPEAT, oldInterval)
+                }
+            }
+
             val autoRunOnBoot = prefs.getBoolean(PrefsKey.AUTO_RUN_ON_BOOT, false)
             val autoRunOnMyPackageReplaced = prefs.getBoolean(PrefsKey.AUTO_RUN_ON_MY_PACKAGE_REPLACED, false)
             val allowWakeLock = prefs.getBoolean(PrefsKey.ALLOW_WAKE_LOCK, true)
             val allowWifiLock = prefs.getBoolean(PrefsKey.ALLOW_WIFI_LOCK, false)
 
             return ForegroundTaskOptions(
-                interval = interval,
-                isOnceEvent = isOnceEvent,
+                eventAction = eventAction,
                 autoRunOnBoot = autoRunOnBoot,
                 autoRunOnMyPackageReplaced = autoRunOnMyPackageReplaced,
                 allowWakeLock = allowWakeLock,
@@ -37,16 +48,19 @@ data class ForegroundTaskOptions(
             val prefs = context.getSharedPreferences(
                 PrefsKey.FOREGROUND_TASK_OPTIONS_PREFS, Context.MODE_PRIVATE)
 
-            val interval = "${map?.get(PrefsKey.TASK_INTERVAL)}".toLongOrNull() ?: 5000L
-            val isOnceEvent = map?.get(PrefsKey.IS_ONCE_EVENT) as? Boolean ?: false
+            val eventActionJson = map?.get(PrefsKey.TASK_EVENT_ACTION) as? Map<*, *>
+            var eventActionJsonString: String? = null
+            if (eventActionJson != null) {
+                eventActionJsonString = JSONObject(eventActionJson).toString()
+            }
+
             val autoRunOnBoot = map?.get(PrefsKey.AUTO_RUN_ON_BOOT) as? Boolean ?: false
             val autoRunOnMyPackageReplaced = map?.get(PrefsKey.AUTO_RUN_ON_MY_PACKAGE_REPLACED) as? Boolean ?: false
             val allowWakeLock = map?.get(PrefsKey.ALLOW_WAKE_LOCK) as? Boolean ?: true
             val allowWifiLock = map?.get(PrefsKey.ALLOW_WIFI_LOCK) as? Boolean ?: false
 
             with(prefs.edit()) {
-                putLong(PrefsKey.TASK_INTERVAL, interval)
-                putBoolean(PrefsKey.IS_ONCE_EVENT, isOnceEvent)
+                putString(PrefsKey.TASK_EVENT_ACTION, eventActionJsonString)
                 putBoolean(PrefsKey.AUTO_RUN_ON_BOOT, autoRunOnBoot)
                 putBoolean(PrefsKey.AUTO_RUN_ON_MY_PACKAGE_REPLACED, autoRunOnMyPackageReplaced)
                 putBoolean(PrefsKey.ALLOW_WAKE_LOCK, allowWakeLock)
@@ -59,16 +73,19 @@ data class ForegroundTaskOptions(
             val prefs = context.getSharedPreferences(
                 PrefsKey.FOREGROUND_TASK_OPTIONS_PREFS, Context.MODE_PRIVATE)
 
-            val interval = "${map?.get(PrefsKey.TASK_INTERVAL)}".toLongOrNull()
-            val isOnceEvent = map?.get(PrefsKey.IS_ONCE_EVENT) as? Boolean
+            val eventActionJson = map?.get(PrefsKey.TASK_EVENT_ACTION) as? Map<*, *>
+            var eventActionJsonString: String? = null
+            if (eventActionJson != null) {
+                eventActionJsonString = JSONObject(eventActionJson).toString()
+            }
+
             val autoRunOnBoot = map?.get(PrefsKey.AUTO_RUN_ON_BOOT) as? Boolean
             val autoRunOnMyPackageReplaced = map?.get(PrefsKey.AUTO_RUN_ON_MY_PACKAGE_REPLACED) as? Boolean
             val allowWakeLock = map?.get(PrefsKey.ALLOW_WAKE_LOCK) as? Boolean
             val allowWifiLock = map?.get(PrefsKey.ALLOW_WIFI_LOCK) as? Boolean
 
             with(prefs.edit()) {
-                interval?.let { putLong(PrefsKey.TASK_INTERVAL, it) }
-                isOnceEvent?.let { putBoolean(PrefsKey.IS_ONCE_EVENT, it) }
+                eventActionJsonString?.let { putString(PrefsKey.TASK_EVENT_ACTION, it) }
                 autoRunOnBoot?.let { putBoolean(PrefsKey.AUTO_RUN_ON_BOOT, it) }
                 autoRunOnMyPackageReplaced?.let { putBoolean(PrefsKey.AUTO_RUN_ON_MY_PACKAGE_REPLACED, it) }
                 allowWakeLock?.let { putBoolean(PrefsKey.ALLOW_WAKE_LOCK, it) }

--- a/documentation/migration_documentation.md
+++ b/documentation/migration_documentation.md
@@ -1,5 +1,30 @@
 ## Migration
 
+### ver 8.6.0
+
+- Remove `interval`, `isOnceEvent` option in ForegroundTaskOptions model.
+- Add `eventAction` option with ForegroundTaskEventAction constructor.
+
+```dart
+// before
+FlutterForegroundTask.init(
+  foregroundTaskOptions: ForegroundTaskOptions(
+    interval: 5000,
+    isOnceEvent: false,
+  ),
+);
+
+// after
+FlutterForegroundTask.init(
+  // ForegroundTaskEventAction.nothing() : Not use onRepeatEvent callback.
+  // ForegroundTaskEventAction.once() : Call onRepeatEvent only once.
+  // ForegroundTaskEventAction.repeat(interval) : Call onRepeatEvent at milliseconds interval.
+  foregroundTaskOptions: ForegroundTaskOptions(
+    eventAction: ForegroundTaskEventAction.repeat(5000),
+  ),
+);
+```
+
 ### ver 8.0.0
 
 - The `sendPort` parameter was removed from the service callback(onStart, onRepeatEvent, onDestroy).
@@ -25,7 +50,7 @@ final ReceivePort? receivePort = FlutterForegroundTask.receivePort;
 receivePort?.listen(_onReceiveTaskData)
 receivePort?.close();
 
-// atfer
+// after
 void main() {
   // Initialize port for communication between TaskHandler and UI.
   FlutterForegroundTask.initCommunicationPort();

--- a/documentation/models_documentation.md
+++ b/documentation/models_documentation.md
@@ -32,12 +32,21 @@ Data class with foreground task options.
 
 | Property                     | Description                                                                                                    |
 |------------------------------|----------------------------------------------------------------------------------------------------------------|
-| `interval`                   | The task call interval in milliseconds. The default is `5000`.                                                 |
-| `isOnceEvent`                | Whether to invoke the onRepeatEvent of `TaskHandler` only once. The default is `false`.                        |
+| `eventAction`                | The action of onRepeatEvent in `TaskHandler`.                                                                  |
 | `autoRunOnBoot`              | Whether to automatically run foreground task on boot. The default is `false`.                                  |
 | `autoRunOnMyPackageReplaced` | Whether to automatically run foreground task when the app is updated to a new version. The default is `false`. |
 | `allowWakeLock`              | Whether to keep the CPU turned on. The default is `true`.                                                      |
 | `allowWifiLock`              | Allows an application to keep the Wi-Fi radio awake. The default is `false`.                                   |
+
+### :chicken: ForegroundTaskEventAction
+
+A class that defines the action of onRepeatEvent in `TaskHandler`.
+
+| factory            | Description                                    |
+|--------------------|------------------------------------------------|
+| `nothing()`        | Not use onRepeatEvent callback.                |
+| `once()`           | Call onRepeatEvent only once.                  |
+| `repeat(interval)` | Call onRepeatEvent at milliseconds `interval`. |
 
 ### :chicken: NotificationIconData
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -27,7 +27,10 @@ class MyTaskHandler extends TaskHandler {
     print('onStart');
   }
 
-  // Called every [ForegroundTaskOptions.interval] milliseconds.
+  // Called by eventAction in [ForegroundTaskOptions].
+  // - nothing() : Not use onRepeatEvent callback.
+  // - once() : Call onRepeatEvent only once.
+  // - repeat(interval) : Call onRepeatEvent at milliseconds interval.
   @override
   void onRepeatEvent(DateTime timestamp) {
     FlutterForegroundTask.updateService(notificationText: 'count: $_count');
@@ -157,9 +160,8 @@ class _ExamplePageState extends State<ExamplePage> {
         showNotification: true,
         playSound: false,
       ),
-      foregroundTaskOptions: const ForegroundTaskOptions(
-        interval: 5000,
-        isOnceEvent: false,
+      foregroundTaskOptions: ForegroundTaskOptions(
+        eventAction: ForegroundTaskEventAction.repeat(5000),
         autoRunOnBoot: true,
         autoRunOnMyPackageReplaced: true,
         allowWakeLock: true,

--- a/ios/Classes/FlutterForegroundTaskLifecycleListener.swift
+++ b/ios/Classes/FlutterForegroundTaskLifecycleListener.swift
@@ -20,7 +20,7 @@ public protocol FlutterForegroundTaskLifecycleListener : AnyObject {
   /** Called when the task is started. */
   func onTaskStart()
 
-  /** Called every ForegroundTaskOptions.interval milliseconds. */
+  /** Called by eventAction in ForegroundTaskOptions. */
   func onTaskRepeatEvent()
   
   /** Called when the task is destroyed. */

--- a/ios/Classes/PreferencesKey.swift
+++ b/ios/Classes/PreferencesKey.swift
@@ -8,11 +8,12 @@
 let SHOW_NOTIFICATION = "showNotification"
 let PLAY_SOUND = "playSound"
 
-let TASK_INTERVAL = "interval"
-let IS_ONCE_EVENT = "isOnceEvent"
-
-let CALLBACK_HANDLE = "callbackHandle"
-
 let NOTIFICATION_CONTENT_TITLE = "notificationContentTitle"
 let NOTIFICATION_CONTENT_TEXT = "notificationContentText"
 let NOTIFICATION_CONTENT_BUTTONS = "buttons"
+
+let TASK_EVENT_ACTION = "taskEventAction" // new
+let INTERVAL = "interval" // deprecated
+let IS_ONCE_EVENT = "isOnceEvent" // deprecated
+
+let CALLBACK_HANDLE = "callbackHandle"

--- a/ios/Classes/models/ForegroundTaskEventAction.swift
+++ b/ios/Classes/models/ForegroundTaskEventAction.swift
@@ -1,0 +1,39 @@
+//
+//  ForegroundTaskEventAction.swift
+//  flutter_foreground_task
+//
+//  Created by Woo Jin Hwang on 8/28/24.
+//
+
+import Foundation
+
+private let TASK_EVENT_TYPE = "taskEventType"
+private let TASK_EVENT_INTERVAL = "taskEventInterval"
+
+struct ForegroundTaskEventAction: Equatable {
+  let type: ForegroundTaskEventType
+  let interval: Int
+  
+  static func fromJsonString(_ jsonString: String) -> ForegroundTaskEventAction {
+    var type: ForegroundTaskEventType = .NOTHING
+    var interval: Int = 5000
+    
+    if let jsonData = jsonString.data(using: .utf8) {
+      if let jsonObj = try? JSONSerialization.jsonObject(with: jsonData, options: []) as? Dictionary<String, Any> {
+        if let typeValue = jsonObj[TASK_EVENT_TYPE] as? Int {
+          type = ForegroundTaskEventType.fromValue(typeValue)
+        }
+        
+        if let intervalValue = jsonObj[TASK_EVENT_INTERVAL] as? Int {
+          interval = intervalValue
+        }
+      }
+    }
+    
+    return ForegroundTaskEventAction(type: type, interval: interval)
+  }
+  
+  static func == (lhs: Self, rhs: Self) -> Bool {
+    return lhs.type.rawValue == rhs.type.rawValue && lhs.interval == rhs.interval
+  }
+}

--- a/ios/Classes/models/ForegroundTaskEventType.swift
+++ b/ios/Classes/models/ForegroundTaskEventType.swift
@@ -1,0 +1,18 @@
+//
+//  ForegroundTaskEventType.swift
+//  flutter_foreground_task
+//
+//  Created by Woo Jin Hwang on 8/28/24.
+//
+
+import Foundation
+
+enum ForegroundTaskEventType: Int {
+  case NOTHING = 1
+  case ONCE = 2
+  case REPEAT = 3
+  
+  static func fromValue(_ value: Int) -> ForegroundTaskEventType {
+    return ForegroundTaskEventType(rawValue: value) ?? .NOTHING
+  }
+}

--- a/lib/flutter_foreground_task.dart
+++ b/lib/flutter_foreground_task.dart
@@ -19,6 +19,7 @@ import 'models/service_request_result.dart';
 
 export 'package:flutter_foreground_task/errors/service_not_initialized_exception.dart';
 export 'package:flutter_foreground_task/errors/service_timeout_exception.dart';
+export 'package:flutter_foreground_task/models/foreground_task_event_action.dart';
 export 'package:flutter_foreground_task/models/foreground_task_options.dart';
 export 'package:flutter_foreground_task/models/ios_notification_options.dart';
 export 'package:flutter_foreground_task/models/notification_button.dart';
@@ -41,7 +42,10 @@ abstract class TaskHandler {
   /// Called when the task is started.
   void onStart(DateTime timestamp);
 
-  /// Called every [ForegroundTaskOptions.interval] milliseconds.
+  /// Called by eventAction in [ForegroundTaskOptions].
+  /// - nothing() : Not use onRepeatEvent callback.
+  /// - once() : Call onRepeatEvent only once.
+  /// - repeat(interval) : Call onRepeatEvent at milliseconds interval.
   void onRepeatEvent(DateTime timestamp);
 
   /// Called when the task is destroyed.

--- a/lib/models/foreground_task_event_action.dart
+++ b/lib/models/foreground_task_event_action.dart
@@ -1,0 +1,50 @@
+/// A class that defines the action of onRepeatEvent in [TaskHandler].
+class ForegroundTaskEventAction {
+  ForegroundTaskEventAction._private({
+    required this.type,
+    this.interval,
+  });
+
+  /// Not use onRepeatEvent callback.
+  factory ForegroundTaskEventAction.nothing() =>
+      ForegroundTaskEventAction._private(type: ForegroundTaskEventType.nothing);
+
+  /// Call onRepeatEvent only once.
+  factory ForegroundTaskEventAction.once() =>
+      ForegroundTaskEventAction._private(type: ForegroundTaskEventType.once);
+
+  /// Call onRepeatEvent at milliseconds [interval].
+  factory ForegroundTaskEventAction.repeat(int interval) =>
+      ForegroundTaskEventAction._private(
+          type: ForegroundTaskEventType.repeat, interval: interval);
+
+  /// The type for [ForegroundTaskEventAction].
+  final ForegroundTaskEventType type;
+
+  /// The interval(in milliseconds) at which onRepeatEvent is invoked.
+  final int? interval;
+
+  /// Returns the data fields of [ForegroundTaskEventAction] in JSON format.
+  Map<String, dynamic> toJson() {
+    return {
+      'taskEventType': type.value,
+      'taskEventInterval': interval,
+    };
+  }
+}
+
+/// The type for [ForegroundTaskEventAction].
+enum ForegroundTaskEventType {
+  /// Not use onRepeatEvent callback.
+  nothing(1),
+
+  /// Call onRepeatEvent only once.
+  once(2),
+
+  /// Call onRepeatEvent at milliseconds interval.
+  repeat(3);
+
+  const ForegroundTaskEventType(this.value);
+
+  final int value;
+}

--- a/lib/models/foreground_task_options.dart
+++ b/lib/models/foreground_task_options.dart
@@ -1,22 +1,18 @@
+import 'foreground_task_event_action.dart';
+
 /// Data class with foreground task options.
 class ForegroundTaskOptions {
   /// Constructs an instance of [ForegroundTaskOptions].
   const ForegroundTaskOptions({
-    this.interval = 5000,
-    this.isOnceEvent = false,
+    required this.eventAction,
     this.autoRunOnBoot = false,
     this.autoRunOnMyPackageReplaced = false,
     this.allowWakeLock = true,
     this.allowWifiLock = false,
-  }) : assert(interval > 0);
+  });
 
-  /// The task call interval in milliseconds.
-  /// The default is `5000`.
-  final int interval;
-
-  /// Whether to invoke the onRepeatEvent of [TaskHandler] only once.
-  /// The default is `false`.
-  final bool isOnceEvent;
+  /// The action of onRepeatEvent in [TaskHandler].
+  final ForegroundTaskEventAction eventAction;
 
   /// Whether to automatically run foreground task on boot.
   /// The default is `false`.
@@ -39,8 +35,7 @@ class ForegroundTaskOptions {
   /// Returns the data fields of [ForegroundTaskOptions] in JSON format.
   Map<String, dynamic> toJson() {
     return {
-      'interval': interval,
-      'isOnceEvent': isOnceEvent,
+      'taskEventAction': eventAction.toJson(),
       'autoRunOnBoot': autoRunOnBoot,
       'autoRunOnMyPackageReplaced': autoRunOnMyPackageReplaced,
       'allowWakeLock': allowWakeLock,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_foreground_task
 description: This plugin is used to implement a foreground service on the Android platform.
-version: 8.5.0
+version: 8.6.0
 homepage: https://github.com/Dev-hwang/flutter_foreground_task
 
 environment:


### PR DESCRIPTION
* [**BREAKING**] Change the way to set the task intervals (for increase scalability)
  - Remove `interval`, `isOnceEvent` option in ForegroundTaskOptions model
  - Add `eventAction` option with ForegroundTaskEventAction constructor
  - Check [migration_documentation](./documentation/migration_documentation.md) for changes