### PR TITLE
release: 8.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## 8.9.0
+
+* [**CHANGE**] Ignore `autoRunOnBoot` option when service is stopped by developer
+* [**CHANGE**] Ignore `autoRunOnBoot` option when android:stopWithTask is set to true
+* [**FEAT**] Add TaskStarter to check who started the task [#276](https://github.com/Dev-hwang/flutter_foreground_task/issues/276)
+  - Add `starter` parameter to `onStart` callback of TaskHandler
+  - `.developer`: The task has been started by the developer (startService, restartService, updateService)
+  - `.system`: The task has been started by the system (reboot, app-updates, AlarmManager-restart)
+* [**FEAT-iOS**] Allow background app refresh
+  - Bump iOS minimumVersion to 13.0
+  - You need to add `BGTaskSchedulerPermittedIdentifiers` key in `ios/Runner/info.plist` file
+  - Check [Getting started-iOS](https://pub.dev/packages/flutter_foreground_task#baby_chick-ios) for more details
+
 ## 8.8.1+1
 
 * [**DOCS**] Update example to see two-way communication flow

--- a/README.md
+++ b/README.md
@@ -14,29 +14,33 @@ This plugin is used to implement a foreground service on the Android platform.
 * Provides useful utilities that can use while performing tasks.
 * Provides option to automatically resume the foreground service on boot.
 
+## Support version
+
+- Flutter: `3.10.0+`
+- Dart: `3.0.0+`
+- Android: `5.0+ (minSdkVersion: 21)`
+- iOS: `13.0+`
+
 ## Getting started
 
 To use this plugin, add `flutter_foreground_task` as a [dependency in your pubspec.yaml file](https://flutter.io/platform-plugins/). For example:
 
 ```yaml
 dependencies:
-  flutter_foreground_task: ^8.8.1+1
+  flutter_foreground_task: ^8.9.0
 ```
 
 After adding the `flutter_foreground_task` plugin to the flutter project, we need to specify the permissions and service to use for this plugin to work properly.
 
 ### :baby_chick: Android
 
-Open the `AndroidManifest.xml` file and specify the service inside the `<application>` tag as follows.
+Open the `AndroidManifest.xml` file and specify the service tag inside the `<application>` tag as follows.
 
 If you want the foreground service to run only when the app is running, add `android:stopWithTask="true"` option.
 
-As it is mentioned in the Android Guidelines, in Android 14, to start a FG service, you need to specify `android:foregroundServiceType`.
+As mentioned in the Android guidelines, to start a FG service on Android 14+, you must specify `android:foregroundServiceType`.
 
 You can read all the details in the Android Developer Page : https://developer.android.com/about/versions/14/changes/fgs-types-required
-
-If you want to target Android 14 phones, you need to add a few lines to your manifest.
-Change the type with your type (all types are listed in the link above).
 
 ```
 <!-- required -->
@@ -57,22 +61,37 @@ Change the type with your type (all types are listed in the link above).
 
 Check runtime requirements before starting the service. If this requirement is not met, the foreground service cannot be started.
 
-<img src="https://github.com/Dev-hwang/flutter_foreground_task/assets/47127353/2a35dada-2c82-41f4-8a45-56776c88e9d3" width="720">
+<img src="https://github.com/Dev-hwang/flutter_foreground_task/assets/47127353/2a35dada-2c82-41f4-8a45-56776c88e9d3" width="700">
 
 ### :baby_chick: iOS
 
 We can also launch `flutter_foreground_task` on the iOS platform. However, it has the following limitations.
 
-* Works only on iOS 12.0 or later.
 * If you force close an app in recent apps, the task will be destroyed immediately.
 * The task cannot be started automatically on boot like Android OS.
-* The task will run in the background for approximately 30 seconds due to background processing limitations. but it works fine in the foreground.
+* The task runs in the background for approximately 30 seconds every 15 minutes. This may take longer than 15 minutes due to iOS limitations.
+
+**Info.plist**:
+
+Add the key below to `ios/Runner/info.plist` file so that the task can run in the background.
+
+```text
+<key>BGTaskSchedulerPermittedIdentifiers</key>
+<array>
+    <string>com.pravera.flutter_foreground_task.refresh</string>
+</array>
+<key>UIBackgroundModes</key>
+<array>
+    <string>fetch</string>
+</array>
+```
 
 **Objective-C**:
 
-1. To use this plugin developed in Swift language in a project using Objective-C, you need to add a bridge header. If you don't have an `ios/Runner/Runner-Bridging-Header.h` file in your project, check this [page](https://developer.apple.com/documentation/swift/imported_c_and_objective-c_apis/importing_objective-c_into_swift).
+To use this plugin developed in Swift in a project using Objective-C, you need to add a bridge header.
+If there is no `ios/Runner/Runner-Bridging-Header.h` file in your project, check this [page](https://developer.apple.com/documentation/swift/imported_c_and_objective-c_apis/importing_objective-c_into_swift).
 
-2. Open the `ios/Runner/AppDelegate.swift` file and add the commented code.
+Open the `ios/Runner/AppDelegate.swift` file and add the commented code.
 
 ```objc
 #import "AppDelegate.h"
@@ -92,7 +111,7 @@ void registerPlugins(NSObject<FlutterPluginRegistry>* registry) {
     didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
   [GeneratedPluginRegistrant registerWithRegistry:self];
 
-  // here, without this code the task will not work.
+  // here
   [FlutterForegroundTaskPlugin setPluginRegistrantCallback:registerPlugins];
   if (@available(iOS 10.0, *)) {
     [UNUserNotificationCenter currentNotificationCenter].delegate = (id<UNUserNotificationCenterDelegate>) self;
@@ -102,18 +121,17 @@ void registerPlugins(NSObject<FlutterPluginRegistry>* registry) {
 }
 
 @end
-
 ```
 
 **Swift**:
 
-1. Declare the import statement below in the `ios/Runner/Runner-Bridging-Header.h` file.
+Declare the import statement below in the `ios/Runner/Runner-Bridging-Header.h` file.
 
 ```objc
 #import <flutter_foreground_task/FlutterForegroundTaskPlugin.h>
 ```
 
-2. Open the `ios/Runner/AppDelegate.swift` file and add the commented code.
+Open the `ios/Runner/AppDelegate.swift` file and add the commented code.
 
 ```swift
 import UIKit
@@ -127,7 +145,7 @@ import Flutter
   ) -> Bool {
     GeneratedPluginRegistrant.register(with: self)
 
-    // here, without this code the task will not work.
+    // here
     SwiftFlutterForegroundTaskPlugin.setPluginRegistrantCallback(registerPlugins)
     if #available(iOS 10.0, *) {
       UNUserNotificationCenter.current().delegate = self as? UNUserNotificationCenterDelegate
@@ -142,12 +160,6 @@ func registerPlugins(registry: FlutterPluginRegistry) {
   GeneratedPluginRegistrant.register(with: registry)
 }
 ```
-
-**Configuring background execution modes**
-
-Background mode settings are required for tasks to be processed in the background. 
-
-See this [page](https://developer.apple.com/documentation/xcode/configuring-background-execution-modes) for settings.
 
 ## How to use
 

--- a/README.md
+++ b/README.md
@@ -176,8 +176,8 @@ void startCallback() {
 class MyTaskHandler extends TaskHandler {
   // Called when the task is started.
   @override
-  void onStart(DateTime timestamp) {
-    print('onStart');
+  void onStart(DateTime timestamp, TaskStarter starter) {
+    print('onStart(starter: ${starter.name})');
   }
 
   // Called by eventAction in [ForegroundTaskOptions].
@@ -393,7 +393,7 @@ class FirstTaskHandler extends TaskHandler {
   int _count = 0;
 
   @override
-  void onStart(DateTime timestamp) {
+  void onStart(DateTime timestamp, TaskStarter starter) {
     // some code
   }
 
@@ -435,7 +435,7 @@ void updateCallback() {
 
 class SecondTaskHandler extends TaskHandler {
   @override
-  void onStart(DateTime timestamp) {
+  void onStart(DateTime timestamp, TaskStarter starter) {
     // some code
   }
 
@@ -481,7 +481,7 @@ JSON and serialization >> https://docs.flutter.dev/data-and-backend/serializatio
 ```dart
 // TaskHandler
 @override
-void onStart(DateTime timestamp) {
+void onStart(DateTime timestamp, TaskStarter starter) {
   // TaskHandler -> Main(UI)
   FlutterForegroundTask.sendDataToMain(Object);
 }
@@ -532,7 +532,7 @@ class MyTaskHandler extends TaskHandler {
   StreamSubscription<Location>? _streamSubscription;
 
   @override
-  void onStart(DateTime timestamp) {
+  void onStart(DateTime timestamp, TaskStarter starter) {
     _streamSubscription = FlLocation.getLocationStream().listen((location) {
       final String message = '${location.latitude}, ${location.longitude}';
       FlutterForegroundTask.updateService(notificationText: message);

--- a/android/src/main/kotlin/com/pravera/flutter_foreground_task/FlutterForegroundTaskLifecycleListener.kt
+++ b/android/src/main/kotlin/com/pravera/flutter_foreground_task/FlutterForegroundTaskLifecycleListener.kt
@@ -13,7 +13,7 @@ interface FlutterForegroundTaskLifecycleListener {
     fun onEngineCreate(flutterEngine: FlutterEngine?)
 
     /** Called when the task is started. */
-    fun onTaskStart()
+    fun onTaskStart(starter: FlutterForegroundTaskStarter)
 
     /** Called by eventAction in ForegroundTaskOptions. */
     fun onTaskRepeatEvent()

--- a/android/src/main/kotlin/com/pravera/flutter_foreground_task/FlutterForegroundTaskStarter.kt
+++ b/android/src/main/kotlin/com/pravera/flutter_foreground_task/FlutterForegroundTaskStarter.kt
@@ -1,0 +1,6 @@
+package com.pravera.flutter_foreground_task
+
+enum class FlutterForegroundTaskStarter {
+    DEVELOPER,
+    SYSTEM
+}

--- a/android/src/main/kotlin/com/pravera/flutter_foreground_task/models/ForegroundServiceAction.kt
+++ b/android/src/main/kotlin/com/pravera/flutter_foreground_task/models/ForegroundServiceAction.kt
@@ -9,9 +9,11 @@ package com.pravera.flutter_foreground_task.models
 object ForegroundServiceAction {
 	private const val prefix = "com.pravera.flutter_foreground_task.action."
 
-	const val START = prefix + "start"
-	const val UPDATE = prefix + "update"
-	const val REBOOT = prefix + "reboot"
-	const val RESTART = prefix + "restart"
-	const val STOP = prefix + "stop"
+    const val API_START = prefix + "api_start"
+    const val API_RESTART = prefix + "api_restart"
+    const val API_UPDATE = prefix + "api_update"
+    const val API_STOP = prefix + "api_stop"
+
+    const val REBOOT = prefix + "reboot"
+    const val RESTART = prefix + "restart"
 }

--- a/android/src/main/kotlin/com/pravera/flutter_foreground_task/models/ForegroundServiceStatus.kt
+++ b/android/src/main/kotlin/com/pravera/flutter_foreground_task/models/ForegroundServiceStatus.kt
@@ -10,7 +10,7 @@ data class ForegroundServiceStatus(val action: String) {
                 PrefsKey.FOREGROUND_SERVICE_STATUS_PREFS, Context.MODE_PRIVATE)
 
             val action = prefs.getString(PrefsKey.FOREGROUND_SERVICE_ACTION, null)
-                ?: ForegroundServiceAction.STOP
+                ?: ForegroundServiceAction.API_STOP
 
             return ForegroundServiceStatus(action = action)
         }
@@ -24,5 +24,9 @@ data class ForegroundServiceStatus(val action: String) {
                 commit()
             }
         }
+    }
+
+    fun isCorrectlyStopped(): Boolean {
+        return action == ForegroundServiceAction.API_STOP
     }
 }

--- a/android/src/main/kotlin/com/pravera/flutter_foreground_task/service/ForegroundServiceManager.kt
+++ b/android/src/main/kotlin/com/pravera/flutter_foreground_task/service/ForegroundServiceManager.kt
@@ -27,7 +27,7 @@ class ForegroundServiceManager {
 
 		val nIntent = Intent(context, ForegroundService::class.java)
 		val argsMap = arguments as? Map<*, *>
-		ForegroundServiceStatus.setData(context, ForegroundServiceAction.START)
+		ForegroundServiceStatus.setData(context, ForegroundServiceAction.API_START)
 		NotificationOptions.setData(context, argsMap)
 		ForegroundTaskOptions.setData(context, argsMap)
 		ForegroundTaskData.setData(context, argsMap)
@@ -42,7 +42,7 @@ class ForegroundServiceManager {
 		}
 
 		val nIntent = Intent(context, ForegroundService::class.java)
-		ForegroundServiceStatus.setData(context, ForegroundServiceAction.RESTART)
+		ForegroundServiceStatus.setData(context, ForegroundServiceAction.API_RESTART)
 		ContextCompat.startForegroundService(context, nIntent)
 	}
 
@@ -54,7 +54,7 @@ class ForegroundServiceManager {
 
 		val nIntent = Intent(context, ForegroundService::class.java)
 		val argsMap = arguments as? Map<*, *>
-		ForegroundServiceStatus.setData(context, ForegroundServiceAction.UPDATE)
+		ForegroundServiceStatus.setData(context, ForegroundServiceAction.API_UPDATE)
 		ForegroundTaskOptions.updateData(context, argsMap)
 		ForegroundTaskData.updateData(context, argsMap)
 		NotificationContent.updateData(context, argsMap)
@@ -68,7 +68,7 @@ class ForegroundServiceManager {
 		}
 
 		val nIntent = Intent(context, ForegroundService::class.java)
-		ForegroundServiceStatus.setData(context, ForegroundServiceAction.STOP)
+		ForegroundServiceStatus.setData(context, ForegroundServiceAction.API_STOP)
 		NotificationOptions.clearData(context)
 		ForegroundTaskOptions.clearData(context)
 		ForegroundTaskData.clearData(context)

--- a/android/src/main/kotlin/com/pravera/flutter_foreground_task/service/RebootReceiver.kt
+++ b/android/src/main/kotlin/com/pravera/flutter_foreground_task/service/RebootReceiver.kt
@@ -26,7 +26,7 @@ class RebootReceiver : BroadcastReceiver() {
 
         // Ignore autoRunOnBoot option when service is stopped by developer.
         val serviceStatus = ForegroundServiceStatus.getData(context)
-        if (serviceStatus.action == ForegroundServiceAction.STOP) {
+        if (serviceStatus.isCorrectlyStopped()) {
             return
         }
 

--- a/android/src/main/kotlin/com/pravera/flutter_foreground_task/service/RestartReceiver.kt
+++ b/android/src/main/kotlin/com/pravera/flutter_foreground_task/service/RestartReceiver.kt
@@ -33,7 +33,7 @@ class RestartReceiver : BroadcastReceiver() {
 				flags = flags or PendingIntent.FLAG_MUTABLE
 			}
 			val operation = PendingIntent.getBroadcast(
-					context, RequestCode.SET_RESTART_SERVICE_ALARM, intent, flags)
+				context, RequestCode.SET_RESTART_SERVICE_ALARM, intent, flags)
 
 			val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
 			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S &&
@@ -52,7 +52,7 @@ class RestartReceiver : BroadcastReceiver() {
 				flags = flags or PendingIntent.FLAG_MUTABLE
 			}
 			val operation = PendingIntent.getBroadcast(
-					context, RequestCode.SET_RESTART_SERVICE_ALARM, intent, flags)
+				context, RequestCode.SET_RESTART_SERVICE_ALARM, intent, flags)
 
 			val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
 			alarmManager.cancel(operation)
@@ -63,22 +63,24 @@ class RestartReceiver : BroadcastReceiver() {
 		if (context == null) return
 
 		val serviceStatus = ForegroundServiceStatus.getData(context)
-		val isCorrectlyStopped = (serviceStatus.action == ForegroundServiceAction.STOP)
+		if (serviceStatus.isCorrectlyStopped()) {
+			return
+		}
 
 		val manager = context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
 		val isRunningService = manager.getRunningServices(Integer.MAX_VALUE)
-				.any { it.service.className == ForegroundService::class.java.name }
-
-		if (!isCorrectlyStopped && !isRunningService) {
-			val isIgnoringBatteryOptimizations = PluginUtils.isIgnoringBatteryOptimizations(context)
-			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && !isIgnoringBatteryOptimizations) {
-				Log.d(TAG, "Turn off battery optimization to restart service in the background.")
-			}
-
-			val nIntent = Intent(context, ForegroundService::class.java)
-			ForegroundServiceStatus.setData(context, ForegroundServiceAction.RESTART)
-			ContextCompat.startForegroundService(context, nIntent)
-			Log.d(TAG, "Restart the service.")
+			.any { it.service.className == ForegroundService::class.java.name }
+		if (isRunningService) {
+			return
 		}
+
+		val isIgnoringBatteryOptimizations = PluginUtils.isIgnoringBatteryOptimizations(context)
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && !isIgnoringBatteryOptimizations) {
+			Log.w(TAG, "Turn off battery optimization to restart service in the background.")
+		}
+
+		val nIntent = Intent(context, ForegroundService::class.java)
+		ForegroundServiceStatus.setData(context, ForegroundServiceAction.RESTART)
+		ContextCompat.startForegroundService(context, nIntent)
 	}
 }

--- a/documentation/models_documentation.md
+++ b/documentation/models_documentation.md
@@ -42,7 +42,7 @@ Data class with foreground task options.
 
 A class that defines the action of onRepeatEvent in `TaskHandler`.
 
-| factory            | Description                                    |
+| Constructor        | Description                                    |
 |--------------------|------------------------------------------------|
 | `nothing()`        | Not use onRepeatEvent callback.                |
 | `once()`           | Call onRepeatEvent only once.                  |
@@ -130,3 +130,12 @@ Result of service request.
 |-----------|-------------------------------------|
 | `success` | Whether the request was successful. |
 | `error`   | Error when the request failed.      |
+
+### :chicken: TaskStarter
+
+The starter that started the task.
+
+| Value       | Description                                 |
+|-------------|---------------------------------------------|
+| `developer` | The task has been started by the developer. |
+| `system`    | The task has been started by the system.    |

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -37,8 +37,8 @@ class MyTaskHandler extends TaskHandler {
 
   // Called when the task is started.
   @override
-  void onStart(DateTime timestamp) {
-    print('onStart');
+  void onStart(DateTime timestamp, TaskStarter starter) {
+    print('onStart(starter: ${starter.name})');
     _incrementCount();
   }
 

--- a/ios/Classes/FlutterForegroundTaskLifecycleListener.swift
+++ b/ios/Classes/FlutterForegroundTaskLifecycleListener.swift
@@ -18,7 +18,7 @@ public protocol FlutterForegroundTaskLifecycleListener : AnyObject {
   func onEngineCreate(flutterEngine: FlutterEngine?)
   
   /** Called when the task is started. */
-  func onTaskStart()
+  func onTaskStart(starter: FlutterForegroundTaskStarter)
 
   /** Called by eventAction in ForegroundTaskOptions. */
   func onTaskRepeatEvent()

--- a/ios/Classes/FlutterForegroundTaskStarter.swift
+++ b/ios/Classes/FlutterForegroundTaskStarter.swift
@@ -1,0 +1,13 @@
+//
+//  FlutterForegroundTaskStarter.swift
+//  flutter_foreground_task
+//
+//  Created by Woo Jin Hwang on 9/23/24.
+//
+
+import Foundation
+
+public enum FlutterForegroundTaskStarter : Int {
+  case DEVELOPER = 0
+  case SYSTEM = 1
+}

--- a/ios/Classes/SwiftFlutterForegroundTaskPlugin.swift
+++ b/ios/Classes/SwiftFlutterForegroundTaskPlugin.swift
@@ -94,12 +94,15 @@ public class SwiftFlutterForegroundTaskPlugin: NSObject, FlutterPlugin {
   }
   
   public func applicationWillTerminate(_ application: UIApplication) {
-    do {
-      try backgroundServiceManager?.stop()
-      sleep(2) // Chance to handle onDestroy before app terminates
-    } catch {
-      // ServiceError.ServiceNotStartedException
+    if !BackgroundService.sharedInstance.isRunningService {
+      return
     }
+    
+    BackgroundServiceStatus.setData(action: BackgroundServiceAction.APP_TERMINATE)
+    BackgroundService.sharedInstance.run()
+    
+    // Chance to handle onDestroy before app terminates
+    sleep(2)
   }
   
   // ================= Service Delegate =================

--- a/ios/Classes/models/BackgroundServiceAction.swift
+++ b/ios/Classes/models/BackgroundServiceAction.swift
@@ -8,8 +8,10 @@
 import Foundation
 
 enum BackgroundServiceAction: String {
-  case START
-  case RESTART
-  case UPDATE
-  case STOP
+  case API_START
+  case API_RESTART
+  case API_UPDATE
+  case API_STOP
+  
+  case APP_TERMINATE
 }

--- a/ios/Classes/models/BackgroundServiceStatus.swift
+++ b/ios/Classes/models/BackgroundServiceStatus.swift
@@ -12,7 +12,7 @@ struct BackgroundServiceStatus {
   
   static func getData() -> BackgroundServiceStatus {
     let prefs = UserDefaults.standard
-    let actionValue = prefs.string(forKey: BACKGROUND_SERVICE_ACTION) ?? BackgroundServiceAction.STOP.rawValue
+    let actionValue = prefs.string(forKey: BACKGROUND_SERVICE_ACTION) ?? BackgroundServiceAction.API_STOP.rawValue
     let action = BackgroundServiceAction(rawValue: actionValue)!
     
     return BackgroundServiceStatus(action: action)

--- a/ios/Classes/service/BackgroundServiceManager.swift
+++ b/ios/Classes/service/BackgroundServiceManager.swift
@@ -19,7 +19,7 @@ class BackgroundServiceManager: NSObject {
         throw ServiceError.ServiceArgumentNullException
       }
       
-      BackgroundServiceStatus.setData(action: BackgroundServiceAction.START)
+      BackgroundServiceStatus.setData(action: BackgroundServiceAction.API_START)
       NotificationOptions.setData(args: args)
       NotificationContent.setData(args: args)
       BackgroundTaskOptions.setData(args: args)
@@ -36,7 +36,7 @@ class BackgroundServiceManager: NSObject {
         throw ServiceError.ServiceNotStartedException
       }
       
-      BackgroundServiceStatus.setData(action: BackgroundServiceAction.RESTART)
+      BackgroundServiceStatus.setData(action: BackgroundServiceAction.API_RESTART)
       BackgroundService.sharedInstance.run()
     } else {
       throw ServiceError.ServiceNotSupportedException
@@ -53,7 +53,7 @@ class BackgroundServiceManager: NSObject {
         throw ServiceError.ServiceArgumentNullException
       }
       
-      BackgroundServiceStatus.setData(action: BackgroundServiceAction.UPDATE)
+      BackgroundServiceStatus.setData(action: BackgroundServiceAction.API_UPDATE)
       NotificationContent.updateData(args: args)
       BackgroundTaskOptions.updateData(args: args)
       BackgroundTaskData.updateData(args: args)
@@ -69,7 +69,7 @@ class BackgroundServiceManager: NSObject {
         throw ServiceError.ServiceNotStartedException
       }
       
-      BackgroundServiceStatus.setData(action: BackgroundServiceAction.STOP)
+      BackgroundServiceStatus.setData(action: BackgroundServiceAction.API_STOP)
       NotificationOptions.clearData()
       NotificationContent.clearData()
       BackgroundTaskOptions.clearData()

--- a/lib/flutter_foreground_task_method_channel.dart
+++ b/lib/flutter_foreground_task_method_channel.dart
@@ -132,7 +132,8 @@ class MethodChannelFlutterForegroundTask extends FlutterForegroundTaskPlatform {
 
     switch (call.method) {
       case 'onStart':
-        handler.onStart(timestamp);
+        final TaskStarter starter = TaskStarter.fromIndex(call.arguments);
+        handler.onStart(timestamp, starter);
         break;
       case 'onRepeatEvent':
         handler.onRepeatEvent(timestamp);

--- a/lib/task_handler.dart
+++ b/lib/task_handler.dart
@@ -3,9 +3,10 @@ import 'flutter_foreground_task.dart';
 /// A class that implements a task handler.
 abstract class TaskHandler {
   /// Called when the task is started.
-  void onStart(DateTime timestamp);
+  void onStart(DateTime timestamp, TaskStarter starter);
 
   /// Called by eventAction in [ForegroundTaskOptions].
+  ///
   /// - nothing() : Not use onRepeatEvent callback.
   /// - once() : Call onRepeatEvent only once.
   /// - repeat(interval) : Call onRepeatEvent at milliseconds interval.
@@ -31,4 +32,15 @@ abstract class TaskHandler {
   /// AOS: only work Android 14+
   /// iOS: only work iOS 10+
   void onNotificationDismissed() {}
+}
+
+/// The starter that started the task.
+enum TaskStarter {
+  /// The task has been started by the developer.
+  developer,
+
+  /// The task has been started by the system.
+  system;
+
+  static TaskStarter fromIndex(int index) => TaskStarter.values[index];
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_foreground_task
 description: This plugin is used to implement a foreground service on the Android platform.
-version: 8.8.1+1
+version: 8.9.0
 homepage: https://github.com/Dev-hwang/flutter_foreground_task
 
 environment:

--- a/test/task_handler_test.dart
+++ b/test/task_handler_test.dart
@@ -53,9 +53,10 @@ void main() {
   group('TaskHandler', () {
     test('onStart', () async {
       const String method = TaskEventMethod.onStart;
+      const TaskStarter starter = TaskStarter.developer;
 
-      await platformChannel.mBGChannel.invokeMethod(method);
-      expect(taskHandler.log.last, isTaskEvent(method));
+      await platformChannel.mBGChannel.invokeMethod(method, starter.index);
+      expect(taskHandler.log.last, isTaskEvent(method, starter.index));
     });
 
     test('onRepeatEvent', () async {
@@ -284,8 +285,8 @@ class TestTaskHandler extends TaskHandler {
   final List<TaskEvent> log = [];
 
   @override
-  void onStart(DateTime timestamp) {
-    log.add(const TaskEvent(method: TaskEventMethod.onStart));
+  void onStart(DateTime timestamp, TaskStarter starter) {
+    log.add(TaskEvent(method: TaskEventMethod.onStart, data: starter.index));
   }
 
   @override


### PR DESCRIPTION
## 8.9.0

* [**CHANGE**] Ignore `autoRunOnBoot` option when service is stopped by developer
* [**CHANGE**] Ignore `autoRunOnBoot` option when android:stopWithTask is set to true
* [**FEAT**] Add TaskStarter to check who started the task [#276](https://github.com/Dev-hwang/flutter_foreground_task/issues/276)
  - Add `starter` parameter to `onStart` callback of TaskHandler
  - `.developer`: The task has been started by the developer (startService, restartService, updateService)
  - `.system`: The task has been started by the system (reboot, app-updates, AlarmManager-restart)
* [**FEAT-iOS**] Allow background app refresh
  - Bump iOS minimumVersion to 13.0
  - You need to add `BGTaskSchedulerPermittedIdentifiers` key in `ios/Runner/info.plist` file
  - Check [Getting started-iOS](https://pub.dev/packages/flutter_foreground_task#baby_chick-ios) for more details