### PR TITLE
release: 8.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 8.10.0
+
+* [**BREAKING**] Change `onStart`, `onDestroy` callback return type from `void` to `Future<void>`
+  - The onRepeatEvent callback is called when the onStart asynchronous operation has finished
+  - Now you can access network, database, and other plugins in onDestroy callback [#276](https://github.com/Dev-hwang/flutter_foreground_task/issues/276)
+  - Check [migration_documentation](./documentation/migration_documentation.md) for changes
+
 ## 8.9.0
 
 * [**CHANGE**] Ignore `autoRunOnBoot` option when service is stopped by developer

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ To use this plugin, add `flutter_foreground_task` as a [dependency in your pubsp
 
 ```yaml
 dependencies:
-  flutter_foreground_task: ^8.9.0
+  flutter_foreground_task: ^8.10.0
 ```
 
 After adding the `flutter_foreground_task` plugin to the flutter project, we need to specify the permissions and service to use for this plugin to work properly.

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ void startCallback() {
 class MyTaskHandler extends TaskHandler {
   // Called when the task is started.
   @override
-  void onStart(DateTime timestamp, TaskStarter starter) {
+  Future<void> onStart(DateTime timestamp, TaskStarter starter) async {
     print('onStart(starter: ${starter.name})');
   }
 
@@ -207,7 +207,7 @@ class MyTaskHandler extends TaskHandler {
 
   // Called when the task is destroyed.
   @override
-  void onDestroy(DateTime timestamp) {
+  Future<void> onDestroy(DateTime timestamp) async {
     print('onDestroy');
   }
 
@@ -405,7 +405,7 @@ class FirstTaskHandler extends TaskHandler {
   int _count = 0;
 
   @override
-  void onStart(DateTime timestamp, TaskStarter starter) {
+  Future<void> onStart(DateTime timestamp, TaskStarter starter) async {
     // some code
   }
 
@@ -435,7 +435,7 @@ class FirstTaskHandler extends TaskHandler {
   }
 
   @override
-  void onDestroy(DateTime timestamp) {
+  Future<void> onDestroy(DateTime timestamp) async {
     // some code
   }
 }
@@ -447,7 +447,7 @@ void updateCallback() {
 
 class SecondTaskHandler extends TaskHandler {
   @override
-  void onStart(DateTime timestamp, TaskStarter starter) {
+  Future<void> onStart(DateTime timestamp, TaskStarter starter) async {
     // some code
   }
 
@@ -466,7 +466,7 @@ class SecondTaskHandler extends TaskHandler {
   }
 
   @override
-  void onDestroy(DateTime timestamp) {
+  Future<void> onDestroy(DateTime timestamp) async {
     // some code
   }
 }
@@ -493,7 +493,7 @@ JSON and serialization >> https://docs.flutter.dev/data-and-backend/serializatio
 ```dart
 // TaskHandler
 @override
-void onStart(DateTime timestamp, TaskStarter starter) {
+Future<void> onStart(DateTime timestamp, TaskStarter starter) async {
   // TaskHandler -> Main(UI)
   FlutterForegroundTask.sendDataToMain(Object);
 }
@@ -544,7 +544,7 @@ class MyTaskHandler extends TaskHandler {
   StreamSubscription<Location>? _streamSubscription;
 
   @override
-  void onStart(DateTime timestamp, TaskStarter starter) {
+  Future<void> onStart(DateTime timestamp, TaskStarter starter) async {
     _streamSubscription = FlLocation.getLocationStream().listen((location) {
       final String message = '${location.latitude}, ${location.longitude}';
       FlutterForegroundTask.updateService(notificationText: message);
@@ -561,7 +561,7 @@ class MyTaskHandler extends TaskHandler {
   }
 
   @override
-  void onDestroy(DateTime timestamp) {
+  Future<void> onDestroy(DateTime timestamp) async {
     _streamSubscription?.cancel();
     _streamSubscription = null;
   }

--- a/android/src/main/kotlin/com/pravera/flutter_foreground_task/service/ForegroundTask.kt
+++ b/android/src/main/kotlin/com/pravera/flutter_foreground_task/service/ForegroundTask.kt
@@ -1,0 +1,187 @@
+package com.pravera.flutter_foreground_task.service
+
+import android.content.Context
+import android.util.Log
+import com.pravera.flutter_foreground_task.FlutterForegroundTaskLifecycleListener
+import com.pravera.flutter_foreground_task.FlutterForegroundTaskStarter
+import com.pravera.flutter_foreground_task.models.ForegroundServiceAction
+import com.pravera.flutter_foreground_task.models.ForegroundServiceStatus
+import com.pravera.flutter_foreground_task.models.ForegroundTaskData
+import com.pravera.flutter_foreground_task.models.ForegroundTaskEventAction
+import com.pravera.flutter_foreground_task.models.ForegroundTaskEventType
+import io.flutter.FlutterInjector
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.embedding.engine.dart.DartExecutor
+import io.flutter.embedding.engine.loader.FlutterLoader
+import io.flutter.plugin.common.MethodCall
+import io.flutter.plugin.common.MethodChannel
+import io.flutter.view.FlutterCallbackInformation
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+class ForegroundTask(
+    context: Context,
+    private val serviceStatus: ForegroundServiceStatus,
+    private val taskData: ForegroundTaskData,
+    private var taskEventAction: ForegroundTaskEventAction,
+    private val taskLifecycleListener: FlutterForegroundTaskLifecycleListener,
+) : MethodChannel.MethodCallHandler {
+    companion object {
+        private val TAG = ForegroundTask::class.java.simpleName
+
+        private const val ACTION_TASK_START = "onStart"
+        private const val ACTION_TASK_REPEAT_EVENT = "onRepeatEvent"
+        private const val ACTION_TASK_DESTROY = "onDestroy"
+    }
+
+    private val flutterEngine: FlutterEngine
+    private val flutterLoader: FlutterLoader
+    private val backgroundChannel: MethodChannel
+    private var repeatTask: Job? = null
+    private var isDestroyed: Boolean = false
+
+    init {
+        // create flutter engine
+        flutterEngine = FlutterEngine(context)
+        flutterLoader = FlutterInjector.instance().flutterLoader()
+        if (!flutterLoader.initialized()) {
+            flutterLoader.startInitialization(context)
+        }
+        flutterLoader.ensureInitializationComplete(context, null)
+        taskLifecycleListener.onEngineCreate(flutterEngine)
+
+        // create background channel
+        val messenger = flutterEngine.dartExecutor.binaryMessenger
+        backgroundChannel = MethodChannel(messenger, "flutter_foreground_task/background")
+        backgroundChannel.setMethodCallHandler(this)
+
+        // execute callback
+        val callbackHandle = taskData.callbackHandle
+        if (callbackHandle != null) {
+            val bundlePath = flutterLoader.findAppBundlePath()
+            val callbackInfo = FlutterCallbackInformation.lookupCallbackInformation(callbackHandle)
+            val dartCallback = DartExecutor.DartCallback(context.assets, bundlePath, callbackInfo)
+            flutterEngine.dartExecutor.executeDartCallback(dartCallback)
+        }
+    }
+
+    override fun onMethodCall(call: MethodCall, result: MethodChannel.Result) {
+        when (call.method) {
+            "start" -> callSafely { start() }
+            else -> result.notImplemented()
+        }
+    }
+
+    private fun start() {
+        val serviceAction = serviceStatus.action
+        val starter = if (serviceAction == ForegroundServiceAction.API_START ||
+            serviceAction == ForegroundServiceAction.API_RESTART ||
+            serviceAction == ForegroundServiceAction.API_UPDATE) {
+            FlutterForegroundTaskStarter.DEVELOPER
+        } else {
+            FlutterForegroundTaskStarter.SYSTEM
+        }
+
+        backgroundChannel.invokeMethod(ACTION_TASK_START, starter.ordinal) {
+            callSafely { startRepeatTask() }
+        }
+
+        taskLifecycleListener.onTaskStart(starter)
+    }
+
+    private fun invokeTaskRepeatEvent() {
+        backgroundChannel.invokeMethod(ACTION_TASK_REPEAT_EVENT, null)
+
+        taskLifecycleListener.onTaskRepeatEvent()
+    }
+
+    private fun startRepeatTask() {
+        stopRepeatTask()
+
+        val type = taskEventAction.type
+        val interval = taskEventAction.interval
+
+        if (type == ForegroundTaskEventType.NOTHING) {
+            return
+        }
+
+        if (type == ForegroundTaskEventType.ONCE) {
+            invokeTaskRepeatEvent()
+            return
+        }
+
+        repeatTask = CoroutineScope(Dispatchers.Default).launch {
+            while (true) {
+                delay(interval)
+                withContext(Dispatchers.Main) {
+                    try {
+                        invokeTaskRepeatEvent()
+                    } catch (e: Exception) {
+                        Log.e(TAG, "repeatTask", e)
+                    }
+                }
+            }
+        }
+    }
+
+    private fun stopRepeatTask() {
+        repeatTask?.cancel()
+        repeatTask = null
+    }
+
+    fun invokeMethod(method: String, data: Any?) {
+        callSafely(onlyCheckDestroyed = true) {
+            backgroundChannel.invokeMethod(method, data)
+        }
+    }
+
+    fun update(taskEventAction: ForegroundTaskEventAction) {
+        callSafely {
+            this.taskEventAction = taskEventAction
+            startRepeatTask()
+        }
+    }
+
+    fun destroy() {
+        callSafely(onlyCheckDestroyed = true) {
+            stopRepeatTask()
+
+            backgroundChannel.setMethodCallHandler(null)
+            backgroundChannel.invokeMethod(ACTION_TASK_DESTROY, null) {
+                flutterEngine.destroy()
+            }
+
+            taskLifecycleListener.onTaskDestroy()
+            taskLifecycleListener.onEngineWillDestroy()
+            isDestroyed = true
+        }
+    }
+
+    private fun callSafely(onlyCheckDestroyed: Boolean = false, call: () -> Unit = {}) {
+        if (isDestroyed || (!onlyCheckDestroyed && taskData.callbackHandle == null)) {
+            return
+        }
+        call()
+    }
+
+    private fun MethodChannel.invokeMethod(method: String, data: Any?, onComplete: () -> Unit = {}) {
+        val callback = object : MethodChannel.Result {
+            override fun success(result: Any?) {
+                onComplete()
+            }
+
+            override fun error(errorCode: String, errorMessage: String?, errorDetails: Any?) {
+                onComplete()
+            }
+
+            override fun notImplemented() {
+                onComplete()
+            }
+        }
+        invokeMethod(method, data, callback)
+    }
+}

--- a/android/src/main/kotlin/com/pravera/flutter_foreground_task/service/ForegroundTaskLifecycleListeners.kt
+++ b/android/src/main/kotlin/com/pravera/flutter_foreground_task/service/ForegroundTaskLifecycleListeners.kt
@@ -1,0 +1,49 @@
+package com.pravera.flutter_foreground_task.service
+
+import com.pravera.flutter_foreground_task.FlutterForegroundTaskLifecycleListener
+import com.pravera.flutter_foreground_task.FlutterForegroundTaskStarter
+import io.flutter.embedding.engine.FlutterEngine
+
+class ForegroundTaskLifecycleListeners : FlutterForegroundTaskLifecycleListener {
+    private var listeners = mutableListOf<FlutterForegroundTaskLifecycleListener>()
+
+    fun addListener(listener: FlutterForegroundTaskLifecycleListener) {
+        if (!listeners.contains(listener)) {
+            listeners.add(listener)
+        }
+    }
+
+    fun removeListener(listener: FlutterForegroundTaskLifecycleListener) {
+        listeners.remove(listener)
+    }
+
+    override fun onEngineCreate(flutterEngine: FlutterEngine?) {
+        for (listener in listeners) {
+            listener.onEngineCreate(flutterEngine)
+        }
+    }
+
+    override fun onTaskStart(starter: FlutterForegroundTaskStarter) {
+        for (listener in listeners) {
+            listener.onTaskStart(starter)
+        }
+    }
+
+    override fun onTaskRepeatEvent() {
+        for (listener in listeners) {
+            listener.onTaskRepeatEvent()
+        }
+    }
+
+    override fun onTaskDestroy() {
+        for (listener in listeners) {
+            listener.onTaskDestroy()
+        }
+    }
+
+    override fun onEngineWillDestroy() {
+        for (listener in listeners) {
+            listener.onEngineWillDestroy()
+        }
+    }
+}

--- a/documentation/migration_documentation.md
+++ b/documentation/migration_documentation.md
@@ -1,5 +1,25 @@
 ## Migration
 
+### ver 8.10.0
+
+- Change onStart, onDestroy callback return type from `void` to `Future<void>`.
+
+```dart
+// before
+@override
+void onStart(DateTime timestamp, TaskStarter starter) { }
+
+@override
+void onDestroy(DateTime timestamp) { }
+
+// after
+@override
+Future<void> onStart(DateTime timestamp, TaskStarter starter) async { }
+
+@override
+Future<void> onDestroy(DateTime timestamp) async { }
+```
+
 ### ver 8.6.0
 
 - Remove `interval`, `isOnceEvent` option in ForegroundTaskOptions model.

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -37,7 +37,7 @@ class MyTaskHandler extends TaskHandler {
 
   // Called when the task is started.
   @override
-  void onStart(DateTime timestamp, TaskStarter starter) {
+  Future<void> onStart(DateTime timestamp, TaskStarter starter) async {
     print('onStart(starter: ${starter.name})');
     _incrementCount();
   }
@@ -53,7 +53,7 @@ class MyTaskHandler extends TaskHandler {
 
   // Called when the task is destroyed.
   @override
-  void onDestroy(DateTime timestamp) {
+  Future<void> onDestroy(DateTime timestamp) async {
     print('onDestroy');
   }
 

--- a/ios/Classes/SwiftFlutterForegroundTaskPlugin.swift
+++ b/ios/Classes/SwiftFlutterForegroundTaskPlugin.swift
@@ -102,7 +102,7 @@ public class SwiftFlutterForegroundTaskPlugin: NSObject, FlutterPlugin {
     BackgroundService.sharedInstance.run()
     
     // Chance to handle onDestroy before app terminates
-    sleep(2)
+    sleep(5)
   }
   
   // ================= Service Delegate =================

--- a/ios/Classes/models/ForegroundTaskData.swift
+++ b/ios/Classes/models/ForegroundTaskData.swift
@@ -1,21 +1,21 @@
 //
-//  BackgroundTaskData.swift
+//  ForegroundTaskData.swift
 //  flutter_foreground_task
 //
-//  Created by Woo Jin Hwang on 8/2/24.
+//  Created by Woo Jin Hwang on 9/24/24.
 //
 
 import Foundation
 
-struct BackgroundTaskData {
+struct ForegroundTaskData {
   let callbackHandle: Int64?
   
-  static func getData() -> BackgroundTaskData {
+  static func getData() -> ForegroundTaskData {
     let prefs = UserDefaults.standard
     
     let callbackHandle = prefs.object(forKey: CALLBACK_HANDLE) as? Int64
     
-    return BackgroundTaskData(callbackHandle: callbackHandle)
+    return ForegroundTaskData(callbackHandle: callbackHandle)
   }
   
   static func setData(args: Dictionary<String, Any>) {

--- a/ios/Classes/models/ForegroundTaskOptions.swift
+++ b/ios/Classes/models/ForegroundTaskOptions.swift
@@ -1,16 +1,16 @@
 //
-//  BackgroundTaskOptions.swift
+//  ForegroundTaskOptions.swift
 //  flutter_foreground_task
 //
-//  Created by Woo Jin Hwang on 8/2/24.
+//  Created by Woo Jin Hwang on 9/24/24.
 //
 
 import Foundation
 
-struct BackgroundTaskOptions {
+struct ForegroundTaskOptions {
   let eventAction: ForegroundTaskEventAction
   
-  static func getData() -> BackgroundTaskOptions {
+  static func getData() -> ForegroundTaskOptions {
     let prefs = UserDefaults.standard
     
     let eventActionJsonString = prefs.string(forKey: TASK_EVENT_ACTION)
@@ -28,7 +28,7 @@ struct BackgroundTaskOptions {
       }
     }
     
-    return BackgroundTaskOptions(eventAction: eventAction)
+    return ForegroundTaskOptions(eventAction: eventAction)
   }
   
   static func setData(args: Dictionary<String, Any>) {

--- a/ios/Classes/service/BackgroundService.swift
+++ b/ios/Classes/service/BackgroundService.swift
@@ -9,16 +9,10 @@ import Flutter
 import Foundation
 import UserNotifications
 
-private let NOTIFICATION_ID: String = "flutter_foreground_task/notification"
-private let NOTIFICATION_CATEGORY_ID: String = "flutter_foreground_task/notification_category"
-private let BG_ISOLATE_NAME: String = "flutter_foreground_task/backgroundIsolate"
-private let BG_CHANNEL_NAME: String = "flutter_foreground_task/background"
+private let NOTIFICATION_ID = "flutter_foreground_task/notification"
+private let NOTIFICATION_CATEGORY_ID = "flutter_foreground_task/notification_category"
 
-private let ACTION_TASK_START: String = "onStart"
-private let ACTION_TASK_REPEAT_EVENT: String = "onRepeatEvent"
-private let ACTION_TASK_DESTROY: String = "onDestroy"
-private let ACTION_RECEIVE_DATA: String = "onReceiveData"
-
+private let ACTION_RECEIVE_DATA = "onReceiveData"
 private let ACTION_NOTIFICATION_BUTTON_PRESSED = "onNotificationButtonPressed"
 private let ACTION_NOTIFICATION_PRESSED = "onNotificationPressed"
 private let ACTION_NOTIFICATION_DISMISSED = "onNotificationDismissed"
@@ -29,28 +23,21 @@ class BackgroundService: NSObject {
   
   private(set) var isRunningService: Bool = false
   
-  private var taskLifecycleListeners: Array<FlutterForegroundTaskLifecycleListener> = []
-  
-  func addTaskLifecycleListener(_ listener: FlutterForegroundTaskLifecycleListener) {
-    if taskLifecycleListeners.contains(where: { $0 === listener }) == false {
-      taskLifecycleListeners.append(listener)
-    }
-  }
-  
-  func removeTaskLifecycleListener(_ listener: FlutterForegroundTaskLifecycleListener) {
-    if let index = taskLifecycleListeners.firstIndex(where: { $0 === listener }) {
-      taskLifecycleListeners.remove(at: index)
-    }
-  }
-  
-  private var flutterEngine: FlutterEngine? = nil
-  private var backgroundChannel: FlutterMethodChannel? = nil
-  private var repeatTask: Timer? = nil
+  private var foregroundTask: ForegroundTask? = nil
+  private var taskLifecycleListeners = ForegroundTaskLifecycleListeners()
   
   func sendData(data: Any?) {
     if isRunningService {
-      backgroundChannel?.invokeMethod(ACTION_RECEIVE_DATA, arguments: data)
+      foregroundTask?.invokeMethod(ACTION_RECEIVE_DATA, arguments: data)
     }
+  }
+  
+  func addTaskLifecycleListener(_ listener: FlutterForegroundTaskLifecycleListener) {
+    taskLifecycleListeners.addListener(listener)
+  }
+  
+  func removeTaskLifecycleListener(_ listener: FlutterForegroundTaskLifecycleListener) {
+    taskLifecycleListeners.removeListener(listener)
   }
   
   private let notificationCenter: UNUserNotificationCenter
@@ -60,10 +47,10 @@ class BackgroundService: NSObject {
   private var backgroundServiceStatus: BackgroundServiceStatus
   private var notificationOptions: NotificationOptions
   private var notificationContent: NotificationContent
-  private var prevBackgroundTaskOptions: BackgroundTaskOptions?
-  private var currBackgroundTaskOptions: BackgroundTaskOptions
-  private var prevBackgroundTaskData: BackgroundTaskData?
-  private var currBackgroundTaskData: BackgroundTaskData
+  private var prevForegroundTaskOptions: ForegroundTaskOptions?
+  private var currForegroundTaskOptions: ForegroundTaskOptions
+  private var prevForegroundTaskData: ForegroundTaskData?
+  private var currForegroundTaskData: ForegroundTaskData
   
   override init() {
     notificationCenter = UNUserNotificationCenter.current()
@@ -71,8 +58,8 @@ class BackgroundService: NSObject {
     backgroundServiceStatus = BackgroundServiceStatus.getData()
     notificationOptions = NotificationOptions.getData()
     notificationContent = NotificationContent.getData()
-    currBackgroundTaskOptions = BackgroundTaskOptions.getData()
-    currBackgroundTaskData = BackgroundTaskData.getData()
+    currForegroundTaskOptions = ForegroundTaskOptions.getData()
+    currForegroundTaskData = ForegroundTaskData.getData()
     super.init()
   }
   
@@ -80,51 +67,36 @@ class BackgroundService: NSObject {
     backgroundServiceStatus = BackgroundServiceStatus.getData()
     notificationOptions = NotificationOptions.getData()
     notificationContent = NotificationContent.getData()
-    prevBackgroundTaskOptions = currBackgroundTaskOptions
-    currBackgroundTaskOptions = BackgroundTaskOptions.getData()
-    prevBackgroundTaskData = currBackgroundTaskData
-    currBackgroundTaskData = BackgroundTaskData.getData()
+    prevForegroundTaskOptions = currForegroundTaskOptions
+    currForegroundTaskOptions = ForegroundTaskOptions.getData()
+    prevForegroundTaskData = currForegroundTaskData
+    currForegroundTaskData = ForegroundTaskData.getData()
 
     switch backgroundServiceStatus.action {
       case .API_START, .API_RESTART:
         requestNotification()
+        createForegroundTask()
         isRunningService = true
-        if let callbackHandle = currBackgroundTaskData.callbackHandle {
-          executeDartCallback(callbackHandle: callbackHandle)
-        }
         break
       case .API_UPDATE:
         requestNotification()
-        isRunningService = true
-        if let callbackHandle = currBackgroundTaskData.callbackHandle {
-          if prevBackgroundTaskData?.callbackHandle != callbackHandle {
-            executeDartCallback(callbackHandle: callbackHandle)
-          } else {
-            let prevEventAction = prevBackgroundTaskOptions?.eventAction
-            let currEventAction = currBackgroundTaskOptions.eventAction
-            if prevEventAction != currEventAction {
-              startRepeatTask()
-            }
+        let prevCallbackHandle = prevForegroundTaskData?.callbackHandle
+        let currCallbackHandle = currForegroundTaskData.callbackHandle
+        if prevCallbackHandle != currCallbackHandle {
+          createForegroundTask()
+        } else {
+          let prevEventAction = prevForegroundTaskOptions?.eventAction
+          let currEventAction = currForegroundTaskOptions.eventAction
+          if prevEventAction != currEventAction {
+            updateForegroundTask()
           }
         }
         break
       case .API_STOP, .APP_TERMINATE:
-        destroyBackgroundTask {
-          self.disposeBackgroundChannel()
-          self.destroyFlutterEngine()
-        }
+        destroyForegroundTask()
         removeAllNotification()
         isRunningService = false
         break
-    }
-  }
-  
-  private func onMethodCall(call: FlutterMethodCall, result: @escaping FlutterResult) {
-    switch call.method {
-      case "startTask":
-        startBackgroundTask()
-      default:
-        result(FlutterMethodNotImplemented)
     }
   }
   
@@ -140,11 +112,11 @@ class BackgroundService: NSObject {
     
     let actionId = response.actionIdentifier
     if notificationContent.buttons.contains(where: { $0.id == actionId }) {
-      backgroundChannel?.invokeMethod(ACTION_NOTIFICATION_BUTTON_PRESSED, arguments: actionId)
+      foregroundTask?.invokeMethod(ACTION_NOTIFICATION_BUTTON_PRESSED, arguments: actionId)
     } else if actionId == UNNotificationDefaultActionIdentifier {
-      backgroundChannel?.invokeMethod(ACTION_NOTIFICATION_PRESSED, arguments: nil)
+      foregroundTask?.invokeMethod(ACTION_NOTIFICATION_PRESSED, arguments: nil)
     } else if actionId == UNNotificationDismissActionIdentifier {
-      backgroundChannel?.invokeMethod(ACTION_NOTIFICATION_DISMISSED, arguments: nil)
+      foregroundTask?.invokeMethod(ACTION_NOTIFICATION_DISMISSED, arguments: nil)
     }
     
     completionHandler()
@@ -212,130 +184,23 @@ class BackgroundService: NSObject {
     notificationCenter.removeDeliveredNotifications(withIdentifiers: [NOTIFICATION_ID])
   }
   
-  private func executeDartCallback(callbackHandle: Int64) {
-    destroyBackgroundTask {
-      if SwiftFlutterForegroundTaskPlugin.registerPlugins == nil {
-        print("Please register the registerPlugins function using the SwiftFlutterForegroundTaskPlugin.setPluginRegistrantCallback.")
-        return
-      }
-      
-      self.destroyFlutterEngine()
-      self.createFlutterEngine()
-      
-      let callbackInfo = FlutterCallbackCache.lookupCallbackInformation(callbackHandle)
-      let entrypoint = callbackInfo?.callbackName
-      let uri = callbackInfo?.callbackLibraryPath
-      self.flutterEngine?.run(withEntrypoint: entrypoint, libraryURI: uri)
-      
-      self.disposeBackgroundChannel()
-      SwiftFlutterForegroundTaskPlugin.registerPlugins!(self.flutterEngine!)
-      self.createBackgroundChannel()
-    }
+  private func createForegroundTask() {
+    destroyForegroundTask()
+    
+    foregroundTask = ForegroundTask(
+      serviceStatus: backgroundServiceStatus,
+      taskData: currForegroundTaskData,
+      taskEventAction: currForegroundTaskOptions.eventAction,
+      taskLifecycleListener: taskLifecycleListeners
+    )
   }
   
-  private func createFlutterEngine() {
-    flutterEngine = FlutterEngine(name: BG_ISOLATE_NAME, project: nil, allowHeadlessExecution: true)
-    for listener in taskLifecycleListeners {
-      listener.onEngineCreate(flutterEngine: flutterEngine!)
-    }
+  private func updateForegroundTask() {
+    foregroundTask?.update(taskEventAction: currForegroundTaskOptions.eventAction)
   }
   
-  private func destroyFlutterEngine() {
-    for listener in taskLifecycleListeners {
-      listener.onEngineWillDestroy()
-    }
-    flutterEngine?.destroyContext()
-    flutterEngine = nil
-  }
-  
-  private func createBackgroundChannel() {
-    let messenger = flutterEngine!.binaryMessenger
-    backgroundChannel = FlutterMethodChannel(name: BG_CHANNEL_NAME, binaryMessenger: messenger)
-    backgroundChannel?.setMethodCallHandler(onMethodCall)
-  }
-  
-  private func disposeBackgroundChannel() {
-    backgroundChannel?.setMethodCallHandler(nil)
-    backgroundChannel = nil
-  }
-  
-  private func startBackgroundTask(onComplete: @escaping () -> Void = {}) {
-    stopRepeatTask()
-    
-    if backgroundChannel == nil {
-      onComplete()
-      return
-    }
-    
-    let serviceAction = backgroundServiceStatus.action
-    let starter: FlutterForegroundTaskStarter
-    switch serviceAction {
-      case .API_START, .API_RESTART, .API_UPDATE:
-        starter = .DEVELOPER
-        break
-      default:
-        starter = .SYSTEM
-        break
-    }
-    
-    backgroundChannel?.invokeMethod(ACTION_TASK_START, arguments: starter.rawValue) { _ in
-      self.startRepeatTask()
-      onComplete()
-    }
-    
-    for listener in self.taskLifecycleListeners {
-      listener.onTaskStart(starter: starter)
-    }
-  }
-  
-  private func destroyBackgroundTask(onComplete: @escaping () -> Void = {}) {
-    stopRepeatTask()
-
-    if backgroundChannel == nil {
-      onComplete()
-      return
-    }
-    
-    backgroundChannel?.invokeMethod(ACTION_TASK_DESTROY, arguments: nil) { _ in
-      onComplete()
-    }
-    
-    for listener in self.taskLifecycleListeners {
-      listener.onTaskDestroy()
-    }
-  }
-  
-  private func invokeTaskRepeatEvent() {
-    backgroundChannel?.invokeMethod(ACTION_TASK_REPEAT_EVENT, arguments: nil)
-    
-    for listener in self.taskLifecycleListeners {
-      listener.onTaskRepeatEvent()
-    }
-  }
-  
-  private func startRepeatTask() {
-    stopRepeatTask()
-    
-    let type = currBackgroundTaskOptions.eventAction.type
-    let interval = currBackgroundTaskOptions.eventAction.interval
-    
-    if type == .NOTHING {
-      return
-    }
-    
-    if type == .ONCE {
-      invokeTaskRepeatEvent()
-      return
-    }
-    
-    let timeInterval = TimeInterval(Double(interval) / 1000)
-    repeatTask = Timer.scheduledTimer(withTimeInterval: timeInterval, repeats: true) { _ in
-      self.invokeTaskRepeatEvent()
-    }
-  }
-  
-  private func stopRepeatTask() {
-    repeatTask?.invalidate()
-    repeatTask = nil
+  private func destroyForegroundTask() {
+    foregroundTask?.destroy()
+    foregroundTask = nil
   }
 }

--- a/ios/Classes/service/BackgroundServiceManager.swift
+++ b/ios/Classes/service/BackgroundServiceManager.swift
@@ -22,8 +22,8 @@ class BackgroundServiceManager: NSObject {
       BackgroundServiceStatus.setData(action: BackgroundServiceAction.API_START)
       NotificationOptions.setData(args: args)
       NotificationContent.setData(args: args)
-      BackgroundTaskOptions.setData(args: args)
-      BackgroundTaskData.setData(args: args)
+      ForegroundTaskOptions.setData(args: args)
+      ForegroundTaskData.setData(args: args)
       BackgroundService.sharedInstance.run()
     } else {
       throw ServiceError.ServiceNotSupportedException
@@ -55,8 +55,8 @@ class BackgroundServiceManager: NSObject {
       
       BackgroundServiceStatus.setData(action: BackgroundServiceAction.API_UPDATE)
       NotificationContent.updateData(args: args)
-      BackgroundTaskOptions.updateData(args: args)
-      BackgroundTaskData.updateData(args: args)
+      ForegroundTaskOptions.updateData(args: args)
+      ForegroundTaskData.updateData(args: args)
       BackgroundService.sharedInstance.run()
     } else {
       throw ServiceError.ServiceNotSupportedException
@@ -72,8 +72,8 @@ class BackgroundServiceManager: NSObject {
       BackgroundServiceStatus.setData(action: BackgroundServiceAction.API_STOP)
       NotificationOptions.clearData()
       NotificationContent.clearData()
-      BackgroundTaskOptions.clearData()
-      BackgroundTaskData.clearData()
+      ForegroundTaskOptions.clearData()
+      ForegroundTaskData.clearData()
       BackgroundService.sharedInstance.run()
     } else {
       throw ServiceError.ServiceNotSupportedException

--- a/ios/Classes/service/ForegroundTask.swift
+++ b/ios/Classes/service/ForegroundTask.swift
@@ -1,0 +1,154 @@
+//
+//  ForegroundTask.swift
+//  flutter_foreground_task
+//
+//  Created by Woo Jin Hwang on 9/24/24.
+//
+
+import Foundation
+
+private let BG_ISOLATE_NAME = "flutter_foreground_task/backgroundIsolate"
+private let BG_CHANNEL_NAME = "flutter_foreground_task/background"
+
+private let ACTION_TASK_START = "onStart"
+private let ACTION_TASK_REPEAT_EVENT = "onRepeatEvent"
+private let ACTION_TASK_DESTROY = "onDestroy"
+
+class ForegroundTask {
+  private let serviceStatus: BackgroundServiceStatus
+  private let taskData: ForegroundTaskData
+  private var taskEventAction: ForegroundTaskEventAction
+  private let taskLifecycleListener: FlutterForegroundTaskLifecycleListener
+  
+  private let flutterEngine: FlutterEngine
+  private let backgroundChannel: FlutterMethodChannel
+  private var repeatTask: Timer? = nil
+  private var isDestroyed: Bool = false
+  
+  init(
+    serviceStatus: BackgroundServiceStatus,
+    taskData: ForegroundTaskData,
+    taskEventAction: ForegroundTaskEventAction,
+    taskLifecycleListener: FlutterForegroundTaskLifecycleListener
+  ) {
+    self.serviceStatus = serviceStatus
+    self.taskData = taskData
+    self.taskEventAction = taskEventAction
+    self.taskLifecycleListener = taskLifecycleListener
+    
+    // create flutter engine
+    flutterEngine = FlutterEngine(name: BG_ISOLATE_NAME, project: nil, allowHeadlessExecution: true)
+    taskLifecycleListener.onEngineCreate(flutterEngine: flutterEngine)
+    
+    // execute callback
+    if let callbackHandle = taskData.callbackHandle {
+      let callbackInfo = FlutterCallbackCache.lookupCallbackInformation(callbackHandle)
+      let dartCallback = callbackInfo?.callbackName
+      let libraryPath = callbackInfo?.callbackLibraryPath
+      flutterEngine.run(withEntrypoint: dartCallback, libraryURI: libraryPath)
+    }
+    
+    // register plugin for creating channel
+    if let registerPlugins = SwiftFlutterForegroundTaskPlugin.registerPlugins {
+      registerPlugins(flutterEngine)
+    } else {
+      print("Please register the registerPlugins function using the SwiftFlutterForegroundTaskPlugin.setPluginRegistrantCallback.")
+    }
+    
+    // create background channel
+    let messenger = flutterEngine.binaryMessenger
+    backgroundChannel = FlutterMethodChannel(name: BG_CHANNEL_NAME, binaryMessenger: messenger)
+    backgroundChannel.setMethodCallHandler(onMethodCall)
+  }
+  
+  func onMethodCall(call: FlutterMethodCall, result: @escaping FlutterResult) {
+    switch call.method {
+      case "start":
+        callSafely { start() }
+      default:
+        result(FlutterMethodNotImplemented)
+    }
+  }
+  
+  private func start() {
+    let serviceAction = serviceStatus.action
+    let starter: FlutterForegroundTaskStarter
+    if serviceAction == .API_START || serviceAction == .API_RESTART || serviceAction == .API_UPDATE {
+      starter = .DEVELOPER
+    } else {
+      starter = .SYSTEM
+    }
+    
+    backgroundChannel.invokeMethod(ACTION_TASK_START, arguments: starter.rawValue) { _ in
+      self.callSafely { self.startRepeatTask() }
+    }
+    
+    taskLifecycleListener.onTaskStart(starter: starter)
+  }
+  
+  private func invokeTaskRepeatEvent() {
+    backgroundChannel.invokeMethod(ACTION_TASK_REPEAT_EVENT, arguments: nil)
+    
+    taskLifecycleListener.onTaskRepeatEvent()
+  }
+  
+  private func startRepeatTask() {
+    stopRepeatTask()
+    
+    let type = taskEventAction.type
+    let interval = TimeInterval(Double(taskEventAction.interval) / 1000)
+    
+    if type == .NOTHING {
+      return
+    }
+    
+    if type == .ONCE {
+      invokeTaskRepeatEvent()
+      return
+    }
+    
+    repeatTask = Timer.scheduledTimer(withTimeInterval: interval, repeats: true) { _ in
+      self.invokeTaskRepeatEvent()
+    }
+  }
+  
+  private func stopRepeatTask() {
+    repeatTask?.invalidate()
+    repeatTask = nil
+  }
+  
+  func invokeMethod(_ method: String, arguments: Any?) {
+    callSafely(onlyCheckDestroyed: true) {
+      backgroundChannel.invokeMethod(method, arguments: arguments)
+    }
+  }
+  
+  func update(taskEventAction: ForegroundTaskEventAction) {
+    callSafely {
+      self.taskEventAction = taskEventAction
+      startRepeatTask()
+    }
+  }
+  
+  func destroy() {
+    callSafely(onlyCheckDestroyed: true) {
+      stopRepeatTask()
+      
+      backgroundChannel.setMethodCallHandler(nil)
+      backgroundChannel.invokeMethod(ACTION_TASK_DESTROY, arguments: nil) { _ in
+        self.flutterEngine.destroyContext()
+      }
+      
+      taskLifecycleListener.onTaskDestroy()
+      taskLifecycleListener.onEngineWillDestroy()
+      isDestroyed = true
+    }
+  }
+  
+  private func callSafely(onlyCheckDestroyed: Bool = false, call: () -> Void = {}) {
+    if isDestroyed || (!onlyCheckDestroyed && taskData.callbackHandle == nil) {
+      return
+    }
+    call()
+  }
+}

--- a/ios/Classes/service/ForegroundTaskLifecycleListeners.swift
+++ b/ios/Classes/service/ForegroundTaskLifecycleListeners.swift
@@ -1,0 +1,54 @@
+//
+//  ForegroundTaskLifecycleListeners.swift
+//  flutter_foreground_task
+//
+//  Created by Woo Jin Hwang on 9/24/24.
+//
+
+import Foundation
+
+class ForegroundTaskLifecycleListeners : FlutterForegroundTaskLifecycleListener {
+  private var listeners: Array<FlutterForegroundTaskLifecycleListener> = []
+  
+  func addListener(_ listener: FlutterForegroundTaskLifecycleListener) {
+    if listeners.contains(where: { $0 === listener }) == false {
+      listeners.append(listener)
+    }
+  }
+  
+  func removeListener(_ listener: FlutterForegroundTaskLifecycleListener) {
+    if let index = listeners.firstIndex(where: { $0 === listener }) {
+      listeners.remove(at: index)
+    }
+  }
+  
+  func onEngineCreate(flutterEngine: FlutterEngine?) {
+    for listener in listeners {
+      listener.onEngineCreate(flutterEngine: flutterEngine)
+    }
+  }
+  
+  func onTaskStart(starter: FlutterForegroundTaskStarter) {
+    for listener in listeners {
+      listener.onTaskStart(starter: starter)
+    }
+  }
+  
+  func onTaskRepeatEvent() {
+    for listener in listeners {
+      listener.onTaskRepeatEvent()
+    }
+  }
+  
+  func onTaskDestroy() {
+    for listener in listeners {
+      listener.onTaskDestroy()
+    }
+  }
+  
+  func onEngineWillDestroy() {
+    for listener in listeners {
+      listener.onEngineWillDestroy()
+    }
+  }
+}

--- a/lib/flutter_foreground_task_method_channel.dart
+++ b/lib/flutter_foreground_task_method_channel.dart
@@ -120,26 +120,26 @@ class MethodChannelFlutterForegroundTask extends FlutterForegroundTaskPlatform {
 
     // Set the method call handler for the background channel.
     mBGChannel.setMethodCallHandler((call) async {
-      onBackgroundChannelMethodCall(call, handler);
+      await onBackgroundChannel(call, handler);
     });
 
-    mBGChannel.invokeMethod('startTask');
+    mBGChannel.invokeMethod('start');
   }
 
   @visibleForTesting
-  void onBackgroundChannelMethodCall(MethodCall call, TaskHandler handler) {
+  Future<void> onBackgroundChannel(MethodCall call, TaskHandler handler) async {
     final DateTime timestamp = DateTime.timestamp();
 
     switch (call.method) {
       case 'onStart':
         final TaskStarter starter = TaskStarter.fromIndex(call.arguments);
-        handler.onStart(timestamp, starter);
+        await handler.onStart(timestamp, starter);
         break;
       case 'onRepeatEvent':
         handler.onRepeatEvent(timestamp);
         break;
       case 'onDestroy':
-        handler.onDestroy(timestamp);
+        await handler.onDestroy(timestamp);
         break;
       case 'onReceiveData':
         dynamic data = call.arguments;

--- a/lib/task_handler.dart
+++ b/lib/task_handler.dart
@@ -3,7 +3,7 @@ import 'flutter_foreground_task.dart';
 /// A class that implements a task handler.
 abstract class TaskHandler {
   /// Called when the task is started.
-  void onStart(DateTime timestamp, TaskStarter starter);
+  Future<void> onStart(DateTime timestamp, TaskStarter starter);
 
   /// Called by eventAction in [ForegroundTaskOptions].
   ///
@@ -13,7 +13,7 @@ abstract class TaskHandler {
   void onRepeatEvent(DateTime timestamp);
 
   /// Called when the task is destroyed.
-  void onDestroy(DateTime timestamp);
+  Future<void> onDestroy(DateTime timestamp);
 
   /// Called when data is sent using [FlutterForegroundTask.sendDataToTask].
   void onReceiveData(Object data) {}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_foreground_task
 description: This plugin is used to implement a foreground service on the Android platform.
-version: 8.9.0
+version: 8.10.0
 homepage: https://github.com/Dev-hwang/flutter_foreground_task
 
 environment:

--- a/test/task_handler_test.dart
+++ b/test/task_handler_test.dart
@@ -36,9 +36,8 @@ void main() {
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(
       platformChannel.mBGChannel,
-      (MethodCall methodCall) async {
-        platformChannel.onBackgroundChannelMethodCall(methodCall, taskHandler);
-        return;
+      (MethodCall methodCall) {
+        return platformChannel.onBackgroundChannel(methodCall, taskHandler);
       },
     );
   });
@@ -285,7 +284,7 @@ class TestTaskHandler extends TaskHandler {
   final List<TaskEvent> log = [];
 
   @override
-  void onStart(DateTime timestamp, TaskStarter starter) {
+  Future<void> onStart(DateTime timestamp, TaskStarter starter) async {
     log.add(TaskEvent(method: TaskEventMethod.onStart, data: starter.index));
   }
 
@@ -295,7 +294,7 @@ class TestTaskHandler extends TaskHandler {
   }
 
   @override
-  void onDestroy(DateTime timestamp) {
+  Future<void> onDestroy(DateTime timestamp) async {
     log.add(const TaskEvent(method: TaskEventMethod.onDestroy));
   }
 


### PR DESCRIPTION
## 8.10.0

* [**BREAKING**] Change `onStart`, `onDestroy` callback return type from `void` to `Future<void>`
  - The onRepeatEvent callback is called when the onStart asynchronous operation has finished
  - Now you can access network, database, and other plugins in onDestroy callback [#276](https://github.com/Dev-hwang/flutter_foreground_task/issues/276)
  - Check [migration_documentation](./documentation/migration_documentation.md) for changes