### PR TITLE
feat-Android: Add setOnlyAlertOnce option to AndroidNotificationOptions

### DIFF
--- a/android/src/main/kotlin/com/pravera/flutter_foreground_task/PreferencesKey.kt
+++ b/android/src/main/kotlin/com/pravera/flutter_foreground_task/PreferencesKey.kt
@@ -29,6 +29,7 @@ object PreferencesKey {
     const val PLAY_SOUND = "playSound"
     const val SHOW_WHEN = "showWhen"
     const val SHOW_BADGE = "showBadge"
+    const val ONLY_ALERT_ONCE = "onlyAlertOnce"
     const val VISIBILITY = "visibility"
 
     // notification content

--- a/android/src/main/kotlin/com/pravera/flutter_foreground_task/models/NotificationOptions.kt
+++ b/android/src/main/kotlin/com/pravera/flutter_foreground_task/models/NotificationOptions.kt
@@ -14,6 +14,7 @@ data class NotificationOptions(
     val playSound: Boolean,
     val showWhen: Boolean,
     val showBadge: Boolean,
+    val onlyAlertOnce: Boolean,
     val visibility: Int
 ) {
     companion object {
@@ -31,6 +32,7 @@ data class NotificationOptions(
             val playSound = prefs.getBoolean(PrefsKey.PLAY_SOUND, false)
             val showWhen = prefs.getBoolean(PrefsKey.SHOW_WHEN, false)
             val showBadge = prefs.getBoolean(PrefsKey.SHOW_BADGE, false)
+            val onlyAlertOnce = prefs.getBoolean(PrefsKey.ONLY_ALERT_ONCE, false)
             val visibility = prefs.getInt(PrefsKey.VISIBILITY, 1)
 
             return NotificationOptions(
@@ -44,6 +46,7 @@ data class NotificationOptions(
                 playSound = playSound,
                 showWhen = showWhen,
                 showBadge = showBadge,
+                onlyAlertOnce = onlyAlertOnce,
                 visibility = visibility
             )
         }
@@ -64,6 +67,7 @@ data class NotificationOptions(
             val playSound = map?.get(PrefsKey.PLAY_SOUND) as? Boolean ?: false
             val showWhen = map?.get(PrefsKey.SHOW_WHEN) as? Boolean ?: false
             val showBadge = map?.get(PrefsKey.SHOW_BADGE) as? Boolean ?: false
+            val onlyAlertOnce = map?.get(PrefsKey.ONLY_ALERT_ONCE) as? Boolean ?: false
             val visibility = map?.get(PrefsKey.VISIBILITY) as? Int ?: 1
 
             with(prefs.edit()) {
@@ -77,6 +81,7 @@ data class NotificationOptions(
                 putBoolean(PrefsKey.PLAY_SOUND, playSound)
                 putBoolean(PrefsKey.SHOW_WHEN, showWhen)
                 putBoolean(PrefsKey.SHOW_BADGE, showBadge)
+                putBoolean(PrefsKey.ONLY_ALERT_ONCE, onlyAlertOnce)
                 putInt(PrefsKey.VISIBILITY, visibility)
                 commit()
             }

--- a/android/src/main/kotlin/com/pravera/flutter_foreground_task/service/ForegroundService.kt
+++ b/android/src/main/kotlin/com/pravera/flutter_foreground_task/service/ForegroundService.kt
@@ -322,6 +322,7 @@ class ForegroundService : Service() {
             builder.setContentText(notificationContent.text)
             builder.style = Notification.BigTextStyle()
             builder.setVisibility(notificationOptions.visibility)
+            builder.setOnlyAlertOnce(notificationOptions.onlyAlertOnce)
             if (iconBackgroundColor != null) {
                 builder.setColor(iconBackgroundColor)
             }
@@ -348,6 +349,7 @@ class ForegroundService : Service() {
             builder.setContentText(notificationContent.text)
             builder.setStyle(NotificationCompat.BigTextStyle().bigText(notificationContent.text))
             builder.setVisibility(notificationOptions.visibility)
+            builder.setOnlyAlertOnce(notificationOptions.onlyAlertOnce)
             if (iconBackgroundColor != null) {
                 builder.color = iconBackgroundColor
             }

--- a/lib/models/notification_options.dart
+++ b/lib/models/notification_options.dart
@@ -16,6 +16,7 @@ class AndroidNotificationOptions {
     this.playSound = false,
     this.showWhen = false,
     this.showBadge = false,
+    this.onlyAlertOnce = false,
     this.visibility = NotificationVisibility.VISIBILITY_PUBLIC,
   })  : assert(channelId.isNotEmpty),
         assert(channelName.isNotEmpty);
@@ -70,6 +71,10 @@ class AndroidNotificationOptions {
   /// It is set only once for the first time on Android 8.0+.
   final bool showBadge;
 
+  /// Whether to only alert once when the notification is created.
+  /// The default is `false`.
+  final bool onlyAlertOnce;
+
   /// Control the level of detail displayed in notifications on the lock screen.
   /// The default is `NotificationVisibility.VISIBILITY_PUBLIC`.
   final NotificationVisibility visibility;
@@ -87,6 +92,7 @@ class AndroidNotificationOptions {
       'playSound': playSound,
       'showWhen': showWhen,
       'showBadge': showBadge,
+      'onlyAlertOnce': onlyAlertOnce,
       'visibility': visibility.rawValue,
     };
   }


### PR DESCRIPTION
Set this flag if you would only like the sound, vibrate and ticker to be played if the notification is not already showing.

Its very useful to prevent the notification alert several times on apps like real time travel monitoring.