### PR TITLE
release: 8.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 8.12.0
+
+* [**FEAT**] Add `setOnlyAlertOnce` option to AndroidNotificationOptions [pr-#287](https://github.com/Dev-hwang/flutter_foreground_task/pull/287)
+* [**CHANGE**] Change notification channel importance from `DEFAULT` to `LOW`
+
 ## 8.11.0
 
 * [**FEAT**] Allow sending Set collection using `FlutterForegroundTask.sendDataToMain`

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ To use this plugin, add `flutter_foreground_task` as a [dependency in your pubsp
 
 ```yaml
 dependencies:
-  flutter_foreground_task: ^8.11.0
+  flutter_foreground_task: ^8.12.0
 ```
 
 After adding the plugin to your flutter project, we need to declare the platform-specific permissions ans service to use for this plugin to work properly.

--- a/README.md
+++ b/README.md
@@ -113,10 +113,10 @@ Open the `ios/Runner/AppDelegate.swift` file and add the commented code.
 #import "AppDelegate.h"
 #import "GeneratedPluginRegistrant.h"
 
-// here
+// this
 #import <flutter_foreground_task/FlutterForegroundTaskPlugin.h>
 
-// here
+// this
 void registerPlugins(NSObject<FlutterPluginRegistry>* registry) {
   [GeneratedPluginRegistrant registerWithRegistry:registry];
 }
@@ -127,7 +127,7 @@ void registerPlugins(NSObject<FlutterPluginRegistry>* registry) {
     didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
   [GeneratedPluginRegistrant registerWithRegistry:self];
 
-  // here
+  // this
   [FlutterForegroundTaskPlugin setPluginRegistrantCallback:registerPlugins];
   if (@available(iOS 10.0, *)) {
     [UNUserNotificationCenter currentNotificationCenter].delegate = (id<UNUserNotificationCenterDelegate>) self;
@@ -153,7 +153,7 @@ Open the `ios/Runner/AppDelegate.swift` file and add the commented code.
 import UIKit
 import Flutter
 
-@UIApplicationMain
+@main
 @objc class AppDelegate: FlutterAppDelegate {
   override func application(
     _ application: UIApplication,
@@ -161,7 +161,7 @@ import Flutter
   ) -> Bool {
     GeneratedPluginRegistrant.register(with: self)
 
-    // here
+    // this
     SwiftFlutterForegroundTaskPlugin.setPluginRegistrantCallback { registry in
       GeneratedPluginRegistrant.register(with: registry)
     }
@@ -234,25 +234,6 @@ class MyTaskHandler extends TaskHandler {
   void onNotificationButtonPressed(String id) {
     print('onNotificationButtonPressed: $id');
   }
-
-  // Called when the notification itself is pressed.
-  //
-  // AOS: "android.permission.SYSTEM_ALERT_WINDOW" permission must be granted
-  // for this function to be called.
-  @override
-  void onNotificationPressed() {
-    FlutterForegroundTask.launchApp('/');
-    print('onNotificationPressed');
-  }
-
-  // Called when the notification itself is dismissed.
-  //
-  // AOS: only work Android 14+
-  // iOS: only work iOS 10+
-  @override
-  void onNotificationDismissed() {
-    print('onNotificationDismissed');
-  }
 }
 ```
 
@@ -299,19 +280,6 @@ Future<void> _requestPermissions() async {
   }
 
   if (Platform.isAndroid) {
-    // "android.permission.SYSTEM_ALERT_WINDOW" permission must be granted for
-    // onNotificationPressed function to be called.
-    //
-    // When the notification is pressed while permission is denied,
-    // the onNotificationPressed function is not called and the app opens.
-    //
-    // If you do not use the onNotificationPressed or launchApp function,
-    // you do not need to write this code.
-    if (!await FlutterForegroundTask.canDrawOverlays) {
-      // This function requires `android.permission.SYSTEM_ALERT_WINDOW` permission.
-      await FlutterForegroundTask.openSystemAlertWindowSettings();
-    }
-
     // Android 12+, there are restrictions on starting a foreground service.
     //
     // To restart the service on device reboot or unexpected problem, you need to allow below permission.
@@ -340,6 +308,7 @@ void _initService() {
       channelName: 'Foreground Service Notification',
       channelDescription:
           'This notification appears when the foreground service is running.',
+      onlyAlertOnce: true,
     ),
     iosNotificationOptions: const IOSNotificationOptions(
       showNotification: false,
@@ -361,9 +330,9 @@ void initState() {
   // Add a callback to receive data sent from the TaskHandler.
   FlutterForegroundTask.addTaskDataCallback(_onReceiveTaskData);
 
-  WidgetsBinding.instance.addPostFrameCallback((_) {
+  WidgetsBinding.instance.addPostFrameCallback((_) async {
     // Request permissions and initialize the service.
-    _requestPermissions();
+    await _requestPermissions();
     _initService();
   });
 }
@@ -432,7 +401,7 @@ class FirstTaskHandler extends TaskHandler {
       );
     } else {
       FlutterForegroundTask.updateService(
-        notificationTitle: 'FirstTask',
+        notificationTitle: 'Hello FirstTaskHandler :)',
         notificationText: timestamp.toString(),
       );
 
@@ -464,7 +433,7 @@ class SecondTaskHandler extends TaskHandler {
   @override
   void onRepeatEvent(DateTime timestamp) {
     FlutterForegroundTask.updateService(
-      notificationTitle: 'SecondTask',
+      notificationTitle: 'Hello SecondTaskHandler :)',
       notificationText: timestamp.toString(),
     );
 
@@ -583,6 +552,7 @@ class MyTaskHandler extends TaskHandler {
 * [`internal_plugin_service`](https://github.com/Dev-hwang/flutter_foreground_task_example/tree/main/internal_plugin_service) (Recommend)
 * [`location_service`](https://github.com/Dev-hwang/flutter_foreground_task_example/tree/main/location_service)
 * [`record_service`](https://github.com/Dev-hwang/flutter_foreground_task_example/tree/main/record_service)
+* [`geofencing_service`](https://github.com/Dev-hwang/flutter_foreground_task_example/tree/main/geofencing_service)
 
 ## More Documentation
 

--- a/README.md
+++ b/README.md
@@ -340,8 +340,6 @@ void _initService() {
       channelName: 'Foreground Service Notification',
       channelDescription:
           'This notification appears when the foreground service is running.',
-      channelImportance: NotificationChannelImportance.LOW,
-      priority: NotificationPriority.LOW,
     ),
     iosNotificationOptions: const IOSNotificationOptions(
       showNotification: false,

--- a/android/src/main/kotlin/com/pravera/flutter_foreground_task/models/NotificationOptions.kt
+++ b/android/src/main/kotlin/com/pravera/flutter_foreground_task/models/NotificationOptions.kt
@@ -26,8 +26,8 @@ data class NotificationOptions(
             val channelId = prefs.getString(PrefsKey.NOTIFICATION_CHANNEL_ID, null) ?: "foreground_service"
             val channelName = prefs.getString(PrefsKey.NOTIFICATION_CHANNEL_NAME, null) ?: "Foreground Service"
             val channelDesc = prefs.getString(PrefsKey.NOTIFICATION_CHANNEL_DESC, null)
-            val channelImportance = prefs.getInt(PrefsKey.NOTIFICATION_CHANNEL_IMPORTANCE, 3)
-            val priority = prefs.getInt(PrefsKey.NOTIFICATION_PRIORITY, 0)
+            val channelImportance = prefs.getInt(PrefsKey.NOTIFICATION_CHANNEL_IMPORTANCE, 2)
+            val priority = prefs.getInt(PrefsKey.NOTIFICATION_PRIORITY, -1)
             val enableVibration = prefs.getBoolean(PrefsKey.ENABLE_VIBRATION, false)
             val playSound = prefs.getBoolean(PrefsKey.PLAY_SOUND, false)
             val showWhen = prefs.getBoolean(PrefsKey.SHOW_WHEN, false)
@@ -61,8 +61,8 @@ data class NotificationOptions(
             val channelId = map?.get(PrefsKey.NOTIFICATION_CHANNEL_ID) as? String
             val channelName = map?.get(PrefsKey.NOTIFICATION_CHANNEL_NAME) as? String
             val channelDesc = map?.get(PrefsKey.NOTIFICATION_CHANNEL_DESC) as? String
-            val channelImportance = map?.get(PrefsKey.NOTIFICATION_CHANNEL_IMPORTANCE) as? Int ?: 3
-            val priority = map?.get(PrefsKey.NOTIFICATION_PRIORITY) as? Int ?: 0
+            val channelImportance = map?.get(PrefsKey.NOTIFICATION_CHANNEL_IMPORTANCE) as? Int ?: 2
+            val priority = map?.get(PrefsKey.NOTIFICATION_PRIORITY) as? Int ?: -1
             val enableVibration = map?.get(PrefsKey.ENABLE_VIBRATION) as? Boolean ?: false
             val playSound = map?.get(PrefsKey.PLAY_SOUND) as? Boolean ?: false
             val showWhen = map?.get(PrefsKey.SHOW_WHEN) as? Boolean ?: false

--- a/documentation/models_documentation.md
+++ b/documentation/models_documentation.md
@@ -4,18 +4,18 @@
 
 Notification options for Android platform.
 
-| Property             | Description                                                                                                                                                 |
-|----------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `channelId`          | Unique ID of the notification channel. It is set only once for the first time on Android 8.0+.                                                              |
-| `channelName`        | The name of the notification channel. It is set only once for the first time on Android 8.0+.                                                               |
-| `channelDescription` | The description of the notification channel. It is set only once for the first time on Android 8.0+.                                                        |
-| `channelImportance`  | The importance of the notification channel. The default is `NotificationChannelImportance.DEFAULT`. It is set only once for the first time on Android 8.0+. |
-| `priority`           | Priority of notifications for Android 7.1 and lower. The default is `NotificationPriority.DEFAULT`.                                                         |
-| `enableVibration`    | Whether to enable vibration when creating notifications. The default is `false`. It is set only once for the first time on Android 8.0+.                    |
-| `playSound`          | Whether to play sound when creating notifications. The default is `false`. It is set only once for the first time on Android 8.0+.                          |
-| `showWhen`           | Whether to show the timestamp when the notification was created in the content view. The default is `false`.                                                |
-| `showBadge`          | Whether to show the badge near the app icon when service is started. The default is `false`. It is set only once for the first time on Android 8.0+.        |
-| `visibility`         | Control the level of detail displayed in notifications on the lock screen. The default is `NotificationVisibility.VISIBILITY_PUBLIC`.                       |
+| Property             | Description                                                                                                                                             |
+|----------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `channelId`          | Unique ID of the notification channel. It is set only once for the first time on Android 8.0+.                                                          |
+| `channelName`        | The name of the notification channel. It is set only once for the first time on Android 8.0+.                                                           |
+| `channelDescription` | The description of the notification channel. It is set only once for the first time on Android 8.0+.                                                    |
+| `channelImportance`  | The importance of the notification channel. The default is `NotificationChannelImportance.LOW`. It is set only once for the first time on Android 8.0+. |
+| `priority`           | Priority of notifications for Android 7.1 and lower. The default is `NotificationPriority.LOW`.                                                         |
+| `enableVibration`    | Whether to enable vibration when creating notifications. The default is `false`. It is set only once for the first time on Android 8.0+.                |
+| `playSound`          | Whether to play sound when creating notifications. The default is `false`. It is set only once for the first time on Android 8.0+.                      |
+| `showWhen`           | Whether to show the timestamp when the notification was created in the content view. The default is `false`.                                            |
+| `showBadge`          | Whether to show the badge near the app icon when service is started. The default is `false`. It is set only once for the first time on Android 8.0+.    |
+| `visibility`         | Control the level of detail displayed in notifications on the lock screen. The default is `NotificationVisibility.VISIBILITY_PUBLIC`.                   |
 
 ### :chicken: IOSNotificationOptions
 

--- a/documentation/models_documentation.md
+++ b/documentation/models_documentation.md
@@ -15,6 +15,7 @@ Notification options for Android platform.
 | `playSound`          | Whether to play sound when creating notifications. The default is `false`. It is set only once for the first time on Android 8.0+.                      |
 | `showWhen`           | Whether to show the timestamp when the notification was created in the content view. The default is `false`.                                            |
 | `showBadge`          | Whether to show the badge near the app icon when service is started. The default is `false`. It is set only once for the first time on Android 8.0+.    |
+| `onlyAlertOnce`      | Whether to only alert once when the notification is created. The default is `false`.                                                                    |
 | `visibility`         | Control the level of detail displayed in notifications on the lock screen. The default is `NotificationVisibility.VISIBILITY_PUBLIC`.                   |
 
 ### :chicken: IOSNotificationOptions

--- a/example/ios/Runner/AppDelegate.swift
+++ b/example/ios/Runner/AppDelegate.swift
@@ -1,7 +1,7 @@
 import UIKit
 import Flutter
 
-@UIApplicationMain
+@main
 @objc class AppDelegate: FlutterAppDelegate {
   override func application(
     _ application: UIApplication,
@@ -9,15 +9,13 @@ import Flutter
   ) -> Bool {
     GeneratedPluginRegistrant.register(with: self)
     
-    SwiftFlutterForegroundTaskPlugin.setPluginRegistrantCallback(registerPlugins)
+    SwiftFlutterForegroundTaskPlugin.setPluginRegistrantCallback { registry in
+      GeneratedPluginRegistrant.register(with: registry)
+    }
     if #available(iOS 10.0, *) {
       UNUserNotificationCenter.current().delegate = self
     }
     
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }
-}
-
-func registerPlugins(registry: FlutterPluginRegistry) {
-  GeneratedPluginRegistrant.register(with: registry)
 }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -167,8 +167,6 @@ class _ExamplePageState extends State<ExamplePage> {
         channelName: 'Foreground Service Notification',
         channelDescription:
             'This notification appears when the foreground service is running.',
-        channelImportance: NotificationChannelImportance.LOW,
-        priority: NotificationPriority.LOW,
       ),
       iosNotificationOptions: const IOSNotificationOptions(
         showNotification: false,

--- a/lib/models/notification_options.dart
+++ b/lib/models/notification_options.dart
@@ -10,8 +10,8 @@ class AndroidNotificationOptions {
     required this.channelId,
     required this.channelName,
     this.channelDescription,
-    this.channelImportance = NotificationChannelImportance.DEFAULT,
-    this.priority = NotificationPriority.DEFAULT,
+    this.channelImportance = NotificationChannelImportance.LOW,
+    this.priority = NotificationPriority.LOW,
     this.enableVibration = false,
     this.playSound = false,
     this.showWhen = false,
@@ -40,13 +40,13 @@ class AndroidNotificationOptions {
   final String? channelDescription;
 
   /// The importance of the notification channel.
-  /// The default is `NotificationChannelImportance.DEFAULT`.
+  /// The default is `NotificationChannelImportance.LOW`.
   ///
   /// It is set only once for the first time on Android 8.0+.
   final NotificationChannelImportance channelImportance;
 
   /// Priority of notifications for Android 7.1 and lower.
-  /// The default is `NotificationPriority.DEFAULT`.
+  /// The default is `NotificationPriority.LOW`.
   final NotificationPriority priority;
 
   /// Whether to enable vibration when creating notifications.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_foreground_task
 description: This plugin is used to implement a foreground service on the Android platform.
-version: 8.11.0
+version: 8.12.0
 homepage: https://github.com/Dev-hwang/flutter_foreground_task
 
 environment:

--- a/test/dummy/service_dummy_data.dart
+++ b/test/dummy/service_dummy_data.dart
@@ -14,8 +14,8 @@ class ServiceDummyData {
     channelId: 'test_channel',
     channelName: 'Test Channel',
     channelDescription: 'Test Channel Description',
-    channelImportance: NotificationChannelImportance.DEFAULT,
-    priority: NotificationPriority.DEFAULT,
+    channelImportance: NotificationChannelImportance.LOW,
+    priority: NotificationPriority.LOW,
     enableVibration: false,
     playSound: false,
     showWhen: false,
@@ -25,7 +25,7 @@ class ServiceDummyData {
 
   final IOSNotificationOptions iosNotificationOptions =
       const IOSNotificationOptions(
-    showNotification: true,
+    showNotification: false,
     playSound: false,
   );
 


### PR DESCRIPTION
## 8.12.0

* [**FEAT**] Add `setOnlyAlertOnce` option to AndroidNotificationOptions [pr-#287](https://github.com/Dev-hwang/flutter_foreground_task/pull/287)
* [**CHANGE**] Change notification channel importance from `DEFAULT` to `LOW`