### PR TITLE
release: 8.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 8.17.0
+
+* [**FEAT**] Allow `onNotificationPressed` to trigger without `SYSTEM_ALERT_WINDOW` permission
+  - Do not use the `launchApp` function inside the `onNotificationPressed` callback
+  - Instead, use the `notificationInitialRoute` option of the `startService` or `updateService` functions
+
 ## 8.16.0
 
 * [**BREAKING**] Change `ServiceRequestResult` class to `sealed class` for improved code readability

--- a/README.md
+++ b/README.md
@@ -227,6 +227,18 @@ class MyTaskHandler extends TaskHandler {
   void onNotificationButtonPressed(String id) {
     print('onNotificationButtonPressed: $id');
   }
+
+  // Called when the notification itself is pressed.
+  @override
+  void onNotificationPressed() {
+    print('onNotificationPressed');
+  }
+
+  // Called when the notification itself is dismissed.
+  @override
+  void onNotificationDismissed() {
+    print('onNotificationDismissed');
+  }
 }
 ```
 
@@ -337,6 +349,7 @@ void initState() {
 * `notificationText`: The text to display in the notification.
 * `notificationIcon`: The icon to display in the notification. Go to [this page](./documentation/customize_notification_icon.md) to customize.
 * `notificationButtons`: The buttons to display in the notification. (can add 0~3 buttons)
+* `notificationInitialRoute`: Initial route to be used when the app is launched via a notification. Works the same as the `launchApp` utility.
 * `callback`: A top-level function that calls the setTaskHandler function.
 
 ```dart
@@ -352,6 +365,7 @@ Future<ServiceRequestResult> _startService() async {
       notificationButtons: [
         const NotificationButton(id: 'btn_hello', text: 'hello'),
       ],
+      notificationInitialRoute: '/',
       callback: startCallback,
     );
   }

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ To use this plugin, add `flutter_foreground_task` as a [dependency in your pubsp
 
 ```yaml
 dependencies:
-  flutter_foreground_task: ^8.16.0
+  flutter_foreground_task: ^8.17.0
 ```
 
 After adding the plugin to your flutter project, we need to declare the platform-specific permissions ans service to use for this plugin to work properly.

--- a/android/src/main/kotlin/com/pravera/flutter_foreground_task/PreferencesKey.kt
+++ b/android/src/main/kotlin/com/pravera/flutter_foreground_task/PreferencesKey.kt
@@ -37,6 +37,7 @@ object PreferencesKey {
     const val NOTIFICATION_CONTENT_TEXT = "notificationContentText"
     const val NOTIFICATION_CONTENT_ICON = "icon"
     const val NOTIFICATION_CONTENT_BUTTONS = "buttons"
+    const val NOTIFICATION_INITIAL_ROUTE = "initialRoute"
 
     // task options
     const val FOREGROUND_TASK_OPTIONS_PREFS = prefix + "FOREGROUND_TASK_OPTIONS"

--- a/android/src/main/kotlin/com/pravera/flutter_foreground_task/RequestCode.kt
+++ b/android/src/main/kotlin/com/pravera/flutter_foreground_task/RequestCode.kt
@@ -13,6 +13,5 @@ object RequestCode {
     // service
     const val SET_RESTART_SERVICE_ALARM = 300
     const val NOTIFICATION_PRESSED = 301
-    const val NOTIFICATION_PRESSED_BROADCAST = 302
-    const val NOTIFICATION_DISMISSED_BROADCAST = 203
+    const val NOTIFICATION_DISMISSED = 302
 }

--- a/android/src/main/kotlin/com/pravera/flutter_foreground_task/models/NotificationContent.kt
+++ b/android/src/main/kotlin/com/pravera/flutter_foreground_task/models/NotificationContent.kt
@@ -9,7 +9,8 @@ data class NotificationContent(
         val title: String,
         val text: String,
         val icon: NotificationIcon?,
-        val buttons: List<NotificationButton>
+        val buttons: List<NotificationButton>,
+        val initialRoute: String?
 ) {
     companion object {
         fun getData(context: Context): NotificationContent {
@@ -35,11 +36,14 @@ data class NotificationContent(
                 }
             }
 
+            val initialRoute = prefs.getString(PrefsKey.NOTIFICATION_INITIAL_ROUTE, null)
+
             return NotificationContent(
                 title = title,
                 text = text,
                 icon = icon,
-                buttons = buttons
+                buttons = buttons,
+                initialRoute = initialRoute
             )
         }
 
@@ -62,11 +66,14 @@ data class NotificationContent(
                 buttonsJsonString = JSONArray(buttonsJson).toString()
             }
 
+            val initialRoute = map?.get(PrefsKey.NOTIFICATION_INITIAL_ROUTE) as? String
+
             with(prefs.edit()) {
                 putString(PrefsKey.NOTIFICATION_CONTENT_TITLE, title)
                 putString(PrefsKey.NOTIFICATION_CONTENT_TEXT, text)
                 putString(PrefsKey.NOTIFICATION_CONTENT_ICON, iconJsonString)
                 putString(PrefsKey.NOTIFICATION_CONTENT_BUTTONS, buttonsJsonString)
+                putString(PrefsKey.NOTIFICATION_INITIAL_ROUTE, initialRoute)
                 commit()
             }
         }
@@ -90,11 +97,14 @@ data class NotificationContent(
                 buttonsJsonString = JSONArray(buttonsJson).toString()
             }
 
+            val initialRoute = map?.get(PrefsKey.NOTIFICATION_INITIAL_ROUTE) as? String
+
             with(prefs.edit()) {
                 title?.let { putString(PrefsKey.NOTIFICATION_CONTENT_TITLE, it) }
                 text?.let { putString(PrefsKey.NOTIFICATION_CONTENT_TEXT, it) }
                 iconJsonString?.let { putString(PrefsKey.NOTIFICATION_CONTENT_ICON, it) }
                 buttonsJsonString?.let { putString(PrefsKey.NOTIFICATION_CONTENT_BUTTONS, it) }
+                initialRoute?.let { putString(PrefsKey.NOTIFICATION_INITIAL_ROUTE, it) }
                 commit()
             }
         }

--- a/android/src/main/kotlin/com/pravera/flutter_foreground_task/service/ForegroundService.kt
+++ b/android/src/main/kotlin/com/pravera/flutter_foreground_task/service/ForegroundService.kt
@@ -488,6 +488,12 @@ class ForegroundService : Service() {
         val packageName = applicationContext.packageName
         val intent = packageManager.getLaunchIntentForPackage(packageName)?.apply {
             putExtra(INTENT_DATA_NAME, ACTION_NOTIFICATION_PRESSED)
+
+            // set initialRoute
+            val initialRoute = notificationContent.initialRoute
+            if (initialRoute != null) {
+                putExtra("route", initialRoute)
+            }
         }
 
         var flags = PendingIntent.FLAG_UPDATE_CURRENT

--- a/android/src/main/kotlin/com/pravera/flutter_foreground_task/utils/PluginUtils.kt
+++ b/android/src/main/kotlin/com/pravera/flutter_foreground_task/utils/PluginUtils.kt
@@ -3,6 +3,7 @@ package com.pravera.flutter_foreground_task.utils
 import android.app.Activity
 import android.app.ActivityManager
 import android.app.ActivityManager.RunningAppProcessInfo
+import android.app.ActivityOptions
 import android.app.AlarmManager
 import android.content.Context
 import android.content.Intent
@@ -52,7 +53,16 @@ class PluginUtils {
                 if (route != null) {
                     launchIntent.putExtra("route", route)
                 }
-                context.startActivity(launchIntent)
+
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                    val options = ActivityOptions.makeBasic().apply {
+                        pendingIntentBackgroundActivityStartMode =
+                                ActivityOptions.MODE_BACKGROUND_ACTIVITY_START_ALLOWED
+                    }
+                    context.startActivity(launchIntent, options.toBundle())
+                } else {
+                    context.startActivity(launchIntent)
+                }
             }
         }
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -67,6 +67,18 @@ class MyTaskHandler extends TaskHandler {
   void onNotificationButtonPressed(String id) {
     print('onNotificationButtonPressed: $id');
   }
+
+  // Called when the notification itself is pressed.
+  @override
+  void onNotificationPressed() {
+    print('onNotificationPressed');
+  }
+
+  // Called when the notification itself is dismissed.
+  @override
+  void onNotificationDismissed() {
+    print('onNotificationDismissed');
+  }
 }
 
 class ExampleApp extends StatelessWidget {
@@ -77,6 +89,7 @@ class ExampleApp extends StatelessWidget {
     return MaterialApp(
       routes: {
         '/': (context) => const ExamplePage(),
+        '/second': (context) => const SecondPage(),
       },
       initialRoute: '/',
     );
@@ -162,6 +175,7 @@ class _ExamplePageState extends State<ExamplePage> {
         notificationButtons: [
           const NotificationButton(id: 'btn_hello', text: 'hello'),
         ],
+        notificationInitialRoute: '/second',
         callback: startCallback,
       );
     }
@@ -210,31 +224,23 @@ class _ExamplePageState extends State<ExamplePage> {
     // This widget must be declared above the [Scaffold] widget.
     return WithForegroundTask(
       child: Scaffold(
-        appBar: _buildAppBar(),
-        body: _buildContent(),
+        appBar: AppBar(
+          title: const Text('Flutter Foreground Task'),
+          centerTitle: true,
+        ),
+        body: SafeArea(
+          child: Column(
+            children: [
+              Expanded(child: _buildCommunicationDataText()),
+              _buildServiceControlButtons(),
+            ],
+          ),
+        ),
       ),
     );
   }
 
-  AppBar _buildAppBar() {
-    return AppBar(
-      title: const Text('Flutter Foreground Task'),
-      centerTitle: true,
-    );
-  }
-
-  Widget _buildContent() {
-    return SafeArea(
-      child: Column(
-        children: [
-          Expanded(child: _buildCommunicationText()),
-          _buildServiceControlButtons(),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildCommunicationText() {
+  Widget _buildCommunicationDataText() {
     return ValueListenableBuilder(
       valueListenable: _taskDataListenable,
       builder: (context, data, _) {
@@ -268,6 +274,26 @@ class _ExamplePageState extends State<ExamplePage> {
           buttonBuilder('stop service', onPressed: _stopService),
           buttonBuilder('increment count', onPressed: _incrementCount),
         ],
+      ),
+    );
+  }
+}
+
+class SecondPage extends StatelessWidget {
+  const SecondPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Second Page'),
+        centerTitle: true,
+      ),
+      body: Center(
+        child: ElevatedButton(
+          onPressed: Navigator.of(context).pop,
+          child: const Text('pop this page'),
+        ),
       ),
     );
   }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -169,8 +169,6 @@ class _ExamplePageState extends State<ExamplePage> {
         serviceId: 256,
         notificationTitle: 'Foreground Service is running',
         notificationText: 'Tap to return to the app',
-        // Please refer to the following document to use a custom notification icon.
-        // https://github.com/Dev-hwang/flutter_foreground_task/blob/master/documentation/customize_notification_icon.md
         notificationIcon: null,
         notificationButtons: [
           const NotificationButton(id: 'btn_hello', text: 'hello'),

--- a/lib/flutter_foreground_task.dart
+++ b/lib/flutter_foreground_task.dart
@@ -100,6 +100,7 @@ class FlutterForegroundTask {
     required String notificationText,
     NotificationIcon? notificationIcon,
     List<NotificationButton>? notificationButtons,
+    String? notificationInitialRoute,
     Function? callback,
   }) async {
     try {
@@ -120,6 +121,7 @@ class FlutterForegroundTask {
         notificationText: notificationText,
         notificationIcon: notificationIcon,
         notificationButtons: notificationButtons,
+        notificationInitialRoute: notificationInitialRoute,
         callback: callback,
       );
 
@@ -155,6 +157,7 @@ class FlutterForegroundTask {
     String? notificationText,
     NotificationIcon? notificationIcon,
     List<NotificationButton>? notificationButtons,
+    String? notificationInitialRoute,
     Function? callback,
   }) async {
     try {
@@ -168,6 +171,7 @@ class FlutterForegroundTask {
         notificationTitle: notificationTitle,
         notificationIcon: notificationIcon,
         notificationButtons: notificationButtons,
+        notificationInitialRoute: notificationInitialRoute,
         callback: callback,
       );
 

--- a/lib/flutter_foreground_task_method_channel.dart
+++ b/lib/flutter_foreground_task_method_channel.dart
@@ -41,6 +41,7 @@ class MethodChannelFlutterForegroundTask extends FlutterForegroundTaskPlatform {
     required String notificationText,
     NotificationIcon? notificationIcon,
     List<NotificationButton>? notificationButtons,
+    String? notificationInitialRoute,
     Function? callback,
   }) async {
     final Map<String, dynamic> optionsJson = ServiceStartOptions(
@@ -52,6 +53,7 @@ class MethodChannelFlutterForegroundTask extends FlutterForegroundTaskPlatform {
       notificationContentText: notificationText,
       notificationIcon: notificationIcon,
       notificationButtons: notificationButtons,
+      notificationInitialRoute: notificationInitialRoute,
       callback: callback,
     ).toJson(platform);
 
@@ -70,6 +72,7 @@ class MethodChannelFlutterForegroundTask extends FlutterForegroundTaskPlatform {
     String? notificationText,
     NotificationIcon? notificationIcon,
     List<NotificationButton>? notificationButtons,
+    String? notificationInitialRoute,
     Function? callback,
   }) async {
     final Map<String, dynamic> optionsJson = ServiceUpdateOptions(
@@ -78,6 +81,7 @@ class MethodChannelFlutterForegroundTask extends FlutterForegroundTaskPlatform {
       notificationContentText: notificationText,
       notificationIcon: notificationIcon,
       notificationButtons: notificationButtons,
+      notificationInitialRoute: notificationInitialRoute,
       callback: callback,
     ).toJson(platform);
 

--- a/lib/flutter_foreground_task_platform_interface.dart
+++ b/lib/flutter_foreground_task_platform_interface.dart
@@ -41,6 +41,7 @@ abstract class FlutterForegroundTaskPlatform extends PlatformInterface {
     required String notificationText,
     NotificationIcon? notificationIcon,
     List<NotificationButton>? notificationButtons,
+    String? notificationInitialRoute,
     Function? callback,
   }) {
     throw UnimplementedError('startService() has not been implemented.');
@@ -56,6 +57,7 @@ abstract class FlutterForegroundTaskPlatform extends PlatformInterface {
     String? notificationText,
     NotificationIcon? notificationIcon,
     List<NotificationButton>? notificationButtons,
+    String? notificationInitialRoute,
     Function? callback,
   }) {
     throw UnimplementedError('updateService() has not been implemented.');

--- a/lib/models/service_options.dart
+++ b/lib/models/service_options.dart
@@ -17,6 +17,7 @@ class ServiceStartOptions {
     required this.notificationContentText,
     this.notificationIcon,
     this.notificationButtons,
+    this.notificationInitialRoute,
     this.callback,
   });
 
@@ -28,6 +29,7 @@ class ServiceStartOptions {
   final String notificationContentText;
   final NotificationIcon? notificationIcon;
   final List<NotificationButton>? notificationButtons;
+  final String? notificationInitialRoute;
   final Function? callback;
 
   Map<String, dynamic> toJson(Platform platform) {
@@ -38,6 +40,7 @@ class ServiceStartOptions {
       'notificationContentText': notificationContentText,
       'icon': notificationIcon?.toJson(),
       'buttons': notificationButtons?.map((e) => e.toJson()).toList(),
+      'initialRoute': notificationInitialRoute,
     };
 
     if (platform.isAndroid) {
@@ -62,6 +65,7 @@ class ServiceUpdateOptions {
     required this.notificationContentText,
     this.notificationIcon,
     this.notificationButtons,
+    this.notificationInitialRoute,
     this.callback,
   });
 
@@ -70,6 +74,7 @@ class ServiceUpdateOptions {
   final String? notificationContentText;
   final NotificationIcon? notificationIcon;
   final List<NotificationButton>? notificationButtons;
+  final String? notificationInitialRoute;
   final Function? callback;
 
   Map<String, dynamic> toJson(Platform platform) {
@@ -78,6 +83,7 @@ class ServiceUpdateOptions {
       'notificationContentText': notificationContentText,
       'icon': notificationIcon?.toJson(),
       'buttons': notificationButtons?.map((e) => e.toJson()).toList(),
+      'initialRoute': notificationInitialRoute,
     };
 
     if (foregroundTaskOptions != null) {

--- a/lib/task_handler.dart
+++ b/lib/task_handler.dart
@@ -22,20 +22,7 @@ abstract class TaskHandler {
   void onNotificationButtonPressed(String id) {}
 
   /// Called when the notification itself is pressed.
-  ///
-  /// - AOS: This callback is triggered only if the
-  /// "android.permission.SYSTEM_ALERT_WINDOW" permission is declared and granted.
-  ///
-  /// ```dart
-  /// void requestPermission() async {
-  ///   if (!await FlutterForegroundTask.canDrawOverlays) {
-  ///     await FlutterForegroundTask.openSystemAlertWindowSettings();
-  ///   }
-  /// }
-  /// ```
-  ///
-  /// - iOS: only work iOS 12+
-  void onNotificationPressed() => FlutterForegroundTask.launchApp();
+  void onNotificationPressed() {}
 
   /// Called when the notification itself is dismissed.
   ///

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_foreground_task
 description: This plugin is used to implement a foreground service on the Android platform.
-version: 8.16.0
+version: 8.17.0
 homepage: https://github.com/Dev-hwang/flutter_foreground_task
 
 environment:


### PR DESCRIPTION
## 8.17.0

* [**FEAT**] Allow `onNotificationPressed` to trigger without `SYSTEM_ALERT_WINDOW` permission
  - Do not use the `launchApp` function inside the `onNotificationPressed` callback
  - Instead, use the `notificationInitialRoute` option of the `startService` or `updateService` functions