### PR TITLE
Fixed two bugs

### DIFF
--- a/android/src/main/kotlin/com/pravera/flutter_foreground_task/service/ForegroundService.kt
+++ b/android/src/main/kotlin/com/pravera/flutter_foreground_task/service/ForegroundService.kt
@@ -171,6 +171,7 @@ class ForegroundService : Service() {
                     } catch (e: ForegroundServiceStartNotAllowedException) {
                         Log.e(TAG,
                             "Cannot run service as foreground: $e for notification channel ")
+                        RestartReceiver.cancelRestartAlarm(this)
                         stopForegroundService()
                     }
                 } else {

--- a/android/src/main/kotlin/com/pravera/flutter_foreground_task/service/ForegroundService.kt
+++ b/android/src/main/kotlin/com/pravera/flutter_foreground_task/service/ForegroundService.kt
@@ -164,8 +164,19 @@ class ForegroundService : Service() {
             }
             ForegroundServiceAction.REBOOT,
             ForegroundServiceAction.RESTART -> {
-                startForegroundService()
-                createForegroundTask()
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                    try {
+                        startForegroundService()
+                        createForegroundTask()
+                    } catch (e: ForegroundServiceStartNotAllowedException) {
+                        Log.e(TAG,
+                            "Cannot run service as foreground: $e for notification channel ")
+                        stopForegroundService()
+                    }
+                } else {
+                    startForegroundService()
+                    createForegroundTask()
+                }
                 Log.d(TAG, "The service has been restarted by Android OS.")
             }
         }

--- a/android/src/main/kotlin/com/pravera/flutter_foreground_task/service/ForegroundService.kt
+++ b/android/src/main/kotlin/com/pravera/flutter_foreground_task/service/ForegroundService.kt
@@ -199,7 +199,10 @@ class ForegroundService : Service() {
         stopForegroundService()
         unregisterBroadcastReceiver()
 
-        val isCorrectlyStopped = foregroundServiceStatus.isCorrectlyStopped()
+        var isCorrectlyStopped = false
+        if (::foregroundServiceStatus.isInitialized) {
+            isCorrectlyStopped = foregroundServiceStatus.isCorrectlyStopped()
+        }
         val isSetStopWithTaskFlag = ForegroundServiceUtils.isSetStopWithTaskFlag(this)
         if (!isCorrectlyStopped && !isSetStopWithTaskFlag) {
             Log.e(TAG, "The service was terminated due to an unexpected problem. The service will restart after 5 seconds.")

--- a/android/src/main/kotlin/com/pravera/flutter_foreground_task/service/RestartReceiver.kt
+++ b/android/src/main/kotlin/com/pravera/flutter_foreground_task/service/RestartReceiver.kt
@@ -2,6 +2,7 @@ package com.pravera.flutter_foreground_task.service
 
 import android.app.ActivityManager
 import android.app.AlarmManager
+import android.app.ForegroundServiceStartNotAllowedException
 import android.app.PendingIntent
 import android.content.BroadcastReceiver
 import android.content.Context
@@ -79,8 +80,18 @@ class RestartReceiver : BroadcastReceiver() {
 			Log.w(TAG, "Turn off battery optimization to restart service in the background.")
 		}
 
-		val nIntent = Intent(context, ForegroundService::class.java)
-		ForegroundServiceStatus.setData(context, ForegroundServiceAction.RESTART)
-		ContextCompat.startForegroundService(context, nIntent)
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+			try {
+				val nIntent = Intent(context, ForegroundService::class.java)
+				ForegroundServiceStatus.setData(context, ForegroundServiceAction.RESTART)
+				ContextCompat.startForegroundService(context, nIntent)
+			} catch (e: ForegroundServiceStartNotAllowedException){
+				Log.e(TAG, "Foreground service start not allowed exception: ${e.message}")
+			}
+		} else {
+			val nIntent = Intent(context, ForegroundService::class.java)
+			ForegroundServiceStatus.setData(context, ForegroundServiceAction.RESTART)
+			ContextCompat.startForegroundService(context, nIntent)
+		}
 	}
 }


### PR DESCRIPTION
Crash reports related to these two issues are being observed in the production environment.
version ：8.14.0 （But the latest version still hasn't fixed it）

_**Our production deployment confirms that the PR changes are operating correctly.**_

**1. About foregroundServiceStatus of UninitializedPropertyAccessException:** 

```
 Caused by kotlin.UninitializedPropertyAccessException: lateinit property foregroundServiceStatus has not been initialized
       at com.pravera.flutter_foreground_task.service.ForegroundService.onDestroy(ForegroundService.kt:171)
       at android.app.ActivityThread.handleStopService(ActivityThread.java:4964)
       at android.app.ActivityThread.-$$Nest$mhandleStopService()
       at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2344)
       at android.os.Handler.dispatchMessage(Handler.java:106)
       at android.os.Looper.loopOnce(Looper.java:240)
       at android.os.Looper.loop(Looper.java:351)
       at android.app.ActivityThread.main(ActivityThread.java:8423)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:584)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1013)
```

**2. About ForegroundServiceStartNotAllowedException:** 

Under legitimate usage, this exception may be reported in extreme cases and is difficult to reproduce. Please refer to here: [issuetracker](https://issuetracker.google.com/issues/307329994?pli=1)

**I followed the [official guidance](https://issuetracker.google.com/issues/307329994#comment86) and implemented try-catch blocks at the relevant code locations.**

```
          Caused by android.app.ForegroundServiceStartNotAllowedException: startForegroundService() not allowed due to mAllowStartForeground false: service com.addcn.android_8591/com.pravera.flutter_foreground_task.service.ForegroundService
       at android.app.ForegroundServiceStartNotAllowedException$1.createFromParcel(ForegroundServiceStartNotAllowedException.java:54)
       at android.app.ForegroundServiceStartNotAllowedException$1.createFromParcel(ForegroundServiceStartNotAllowedException.java:50)
       at android.os.Parcel.readParcelableInternal(Parcel.java:4892)
       at android.os.Parcel.readParcelable(Parcel.java:4874)
       at android.os.Parcel.createExceptionOrNull(Parcel.java:3074)
       at android.os.Parcel.createException(Parcel.java:3063)
       at android.os.Parcel.readException(Parcel.java:3046)
       at android.os.Parcel.readException(Parcel.java:2988)
       at android.app.IActivityManager$Stub$Proxy.startService(IActivityManager.java:6492)
       at android.app.ContextImpl.startServiceCommon(ContextImpl.java:1942)
       at android.app.ContextImpl.startForegroundService(ContextImpl.java:1917)
       at android.content.ContextWrapper.startForegroundService(ContextWrapper.java:841)
       at android.content.ContextWrapper.startForegroundService(ContextWrapper.java:841)
       at androidx.core.content.ContextCompat$Api26Impl.startForegroundService(ContextCompat.java)
       at androidx.core.content.ContextCompat.startForegroundService(ContextCompat.java:700)
       at com.pravera.flutter_foreground_task.service.RestartReceiver.onReceive(RestartReceiver.kt:74)
       at android.app.ActivityThread.handleReceiver(ActivityThread.java:4673)
       at android.app.ActivityThread.-$$Nest$mhandleReceiver()
       at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2402)
       at android.os.Handler.dispatchMessage(Handler.java:106)
       at android.os.Looper.loopOnce(Looper.java:224)
       at android.os.Looper.loop(Looper.java:318)
       at android.app.ActivityThread.main(ActivityThread.java:8777)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:561)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1013)
```