### PR TITLE
release: 9.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 9.0.0
+
+* [**CHORE**] Bump minimum supported SDK version to `Flutter 3.22/Dart 3.4`
+* [**CHORE**] Bump `kotlin_version(1.7.10 -> 1.9.10)`, `gradle(7.3.0 -> 8.6.0)` for Android 15
+* [**FEAT**] Add `isTimeout` param to the onDestroy callback
+* [**FIX**] Fix "null object" error [#332](https://github.com/Dev-hwang/flutter_foreground_task/issues/332)
+* [**FIX**] Fix "Reply already submitted" error [#330](https://github.com/Dev-hwang/flutter_foreground_task/issues/330)
+* [**FIX**] Prevent crash by catching exceptions during foreground service start
+* Check [migration_documentation](./documentation/migration_documentation.md) for changes
+
 ## 8.17.0
 
 * [**FEAT**] Allow `onNotificationPressed` to trigger without `SYSTEM_ALERT_WINDOW` permission

--- a/README.md
+++ b/README.md
@@ -27,12 +27,19 @@ To use this plugin, add `flutter_foreground_task` as a [dependency in your pubsp
 
 ```yaml
 dependencies:
-  flutter_foreground_task: ^8.17.0
+  flutter_foreground_task: ^9.0.0
 ```
 
 After adding the plugin to your flutter project, we need to declare the platform-specific permissions ans service to use for this plugin to work properly.
 
 ### :baby_chick: Android
+
+This plugin requires `Kotlin version 1.9.10+` and `Gradle version 8.6.0+`. Please refer to the migration documentation for more details.
+
+- [project/settings.gradle](https://github.com/Dev-hwang/flutter_foreground_task/blob/master/example/android/settings.gradle)
+- [project/gradle-wrapper.properties](https://github.com/Dev-hwang/flutter_foreground_task/blob/master/example/android/gradle/wrapper/gradle-wrapper.properties)
+- [app/build.gradle](https://github.com/Dev-hwang/flutter_foreground_task/blob/master/example/android/app/build.gradle)
+- [migration_documentation](https://github.com/Dev-hwang/flutter_foreground_task/blob/master/documentation/migration_documentation.md)
 
 Open the `AndroidManifest.xml` file and declare the service tag inside the `<application>` tag as follows.
 

--- a/README.md
+++ b/README.md
@@ -71,9 +71,23 @@ As mentioned in the Android guidelines, to start a FG service on Android 14+, yo
     android:exported="false" />
 ```
 
-Check runtime requirements before starting the service. If this requirement is not met, the foreground service cannot be started.
+> [!CAUTION]
+> Check [runtime requirements](https://developer.android.com/about/versions/14/changes/fgs-types-required#system-runtime-checks) before starting the service. If this requirement is not met, the foreground service cannot be started.
 
-<img src="https://github.com/Dev-hwang/flutter_foreground_task/assets/47127353/2a35dada-2c82-41f4-8a45-56776c88e9d3" width="700">
+> [!CAUTION]
+> Android 15 introduces a new timeout behavior to `dataSync` for apps targeting Android 15 (API level 35) or higher.
+> The system permits an app's `dataSync` services to run for a total of 6 hours in a 24-hour period.
+> However, if the user brings the app to the foreground, the timer resets and the app has 6 hours available.
+>
+> There are new restrictions on `BOOT_COMPLETED(autoRunOnBoot)` broadcast receivers launching foreground services.
+> `BOOT_COMPLETED` receivers are not allowed to launch the following types of foreground services:
+> - [dataSync](https://developer.android.com/develop/background-work/services/fg-service-types#data-sync)
+> - [camera](https://developer.android.com/develop/background-work/services/fg-service-types#camera)
+> - [mediaPlayback](https://developer.android.com/develop/background-work/services/fg-service-types#media)
+> - [phoneCall](https://developer.android.com/develop/background-work/services/fg-service-types#phone-call)
+> - [microphone](https://developer.android.com/about/versions/14/changes/fgs-types-required#microphone)
+> 
+> You can find how to test this behavior and more details at this [link](https://developer.android.com/about/versions/15/behavior-changes-15#fgs-hardening).
 
 ### :baby_chick: iOS
 
@@ -212,8 +226,8 @@ class MyTaskHandler extends TaskHandler {
 
   // Called when the task is destroyed.
   @override
-  Future<void> onDestroy(DateTime timestamp) async {
-    print('onDestroy');
+  Future<void> onDestroy(DateTime timestamp, bool isTimeout) async {
+    print('onDestroy(isTimeout: $isTimeout)');
   }
 
   // Called when data is sent using `FlutterForegroundTask.sendDataToTask`.
@@ -428,7 +442,7 @@ class FirstTaskHandler extends TaskHandler {
   }
 
   @override
-  Future<void> onDestroy(DateTime timestamp) async {
+  Future<void> onDestroy(DateTime timestamp, bool isTimeout) async {
     // some code
   }
 }
@@ -459,7 +473,7 @@ class SecondTaskHandler extends TaskHandler {
   }
 
   @override
-  Future<void> onDestroy(DateTime timestamp) async {
+  Future<void> onDestroy(DateTime timestamp, bool isTimeout) async {
     // some code
   }
 }
@@ -554,7 +568,7 @@ class MyTaskHandler extends TaskHandler {
   }
 
   @override
-  Future<void> onDestroy(DateTime timestamp) async {
+  Future<void> onDestroy(DateTime timestamp, bool isTimeout) async {
     _streamSubscription?.cancel();
     _streamSubscription = null;
   }

--- a/android/src/main/kotlin/com/pravera/flutter_foreground_task/service/ForegroundService.kt
+++ b/android/src/main/kotlin/com/pravera/flutter_foreground_task/service/ForegroundService.kt
@@ -61,7 +61,7 @@ class ForegroundService : Service() {
             try {
                 // Check if the given intent is a LaunchIntent.
                 val isLaunchIntent = (intent.action == Intent.ACTION_MAIN) &&
-                        intent.categories.contains(Intent.CATEGORY_LAUNCHER)
+                        (intent.categories?.contains(Intent.CATEGORY_LAUNCHER) == true)
                 if (!isLaunchIntent) {
                     // Log.d(TAG, "not LaunchIntent")
                     return

--- a/android/src/main/kotlin/com/pravera/flutter_foreground_task/service/ForegroundTask.kt
+++ b/android/src/main/kotlin/com/pravera/flutter_foreground_task/service/ForegroundTask.kt
@@ -152,7 +152,7 @@ class ForegroundTask(
         }
     }
 
-    fun destroy() {
+    fun destroy(isTimeout: Boolean) {
         runIfNotDestroyed {
             stopRepeatTask()
 
@@ -161,7 +161,7 @@ class ForegroundTask(
                 taskLifecycleListener.onEngineWillDestroy()
                 flutterEngine.destroy()
             } else {
-                backgroundChannel.invokeMethod(ACTION_TASK_DESTROY, null) {
+                backgroundChannel.invokeMethod(ACTION_TASK_DESTROY, isTimeout) {
                     flutterEngine.destroy()
                 }
                 taskLifecycleListener.onTaskDestroy()

--- a/android/src/main/kotlin/com/pravera/flutter_foreground_task/service/RebootReceiver.kt
+++ b/android/src/main/kotlin/com/pravera/flutter_foreground_task/service/RebootReceiver.kt
@@ -1,8 +1,11 @@
 package com.pravera.flutter_foreground_task.service
 
+import android.app.ForegroundServiceStartNotAllowedException
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import android.os.Build
+import android.util.Log
 import androidx.core.content.ContextCompat
 import com.pravera.flutter_foreground_task.models.ForegroundServiceAction
 import com.pravera.flutter_foreground_task.models.ForegroundServiceStatus
@@ -16,6 +19,10 @@ import com.pravera.flutter_foreground_task.utils.ForegroundServiceUtils
  * @version 1.0
  */
 class RebootReceiver : BroadcastReceiver() {
+    companion object {
+        private val TAG = RebootReceiver::class.java.simpleName
+    }
+
     override fun onReceive(context: Context?, intent: Intent?) {
         if (context == null || intent == null) return
 
@@ -45,9 +52,24 @@ class RebootReceiver : BroadcastReceiver() {
     }
 
     private fun startForegroundService(context: Context) {
-        // Create an intent for calling the service and store the action to be executed
-        val nIntent = Intent(context, ForegroundService::class.java)
-        ForegroundServiceStatus.setData(context, ForegroundServiceAction.REBOOT)
-        ContextCompat.startForegroundService(context, nIntent)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            try {
+                val nIntent = Intent(context, ForegroundService::class.java)
+                ForegroundServiceStatus.setData(context, ForegroundServiceAction.REBOOT)
+                ContextCompat.startForegroundService(context, nIntent)
+            } catch (e: ForegroundServiceStartNotAllowedException) {
+                Log.e(TAG, "Foreground service start not allowed exception: ${e.message}")
+            } catch (e: Exception) {
+                Log.e(TAG, e.message, e)
+            }
+        } else {
+            try {
+                val nIntent = Intent(context, ForegroundService::class.java)
+                ForegroundServiceStatus.setData(context, ForegroundServiceAction.REBOOT)
+                ContextCompat.startForegroundService(context, nIntent)
+            } catch (e: Exception) {
+                Log.e(TAG, e.message, e)
+            }
+        }
     }
 }

--- a/android/src/main/kotlin/com/pravera/flutter_foreground_task/service/RestartReceiver.kt
+++ b/android/src/main/kotlin/com/pravera/flutter_foreground_task/service/RestartReceiver.kt
@@ -85,13 +85,19 @@ class RestartReceiver : BroadcastReceiver() {
 				val nIntent = Intent(context, ForegroundService::class.java)
 				ForegroundServiceStatus.setData(context, ForegroundServiceAction.RESTART)
 				ContextCompat.startForegroundService(context, nIntent)
-			} catch (e: ForegroundServiceStartNotAllowedException){
+			} catch (e: ForegroundServiceStartNotAllowedException) {
 				Log.e(TAG, "Foreground service start not allowed exception: ${e.message}")
+			} catch (e: Exception) {
+				Log.e(TAG, e.toString())
 			}
 		} else {
-			val nIntent = Intent(context, ForegroundService::class.java)
-			ForegroundServiceStatus.setData(context, ForegroundServiceAction.RESTART)
-			ContextCompat.startForegroundService(context, nIntent)
+			try {
+				val nIntent = Intent(context, ForegroundService::class.java)
+				ForegroundServiceStatus.setData(context, ForegroundServiceAction.RESTART)
+				ContextCompat.startForegroundService(context, nIntent)
+			} catch (e: Exception) {
+				Log.e(TAG, e.toString())
+			}
 		}
 	}
 }

--- a/android/src/main/kotlin/com/pravera/flutter_foreground_task/service/RestartReceiver.kt
+++ b/android/src/main/kotlin/com/pravera/flutter_foreground_task/service/RestartReceiver.kt
@@ -88,7 +88,7 @@ class RestartReceiver : BroadcastReceiver() {
 			} catch (e: ForegroundServiceStartNotAllowedException) {
 				Log.e(TAG, "Foreground service start not allowed exception: ${e.message}")
 			} catch (e: Exception) {
-				Log.e(TAG, e.toString())
+				Log.e(TAG, e.message, e)
 			}
 		} else {
 			try {
@@ -96,7 +96,7 @@ class RestartReceiver : BroadcastReceiver() {
 				ForegroundServiceStatus.setData(context, ForegroundServiceAction.RESTART)
 				ContextCompat.startForegroundService(context, nIntent)
 			} catch (e: Exception) {
-				Log.e(TAG, e.toString())
+				Log.e(TAG, e.message, e)
 			}
 		}
 	}

--- a/documentation/migration_documentation.md
+++ b/documentation/migration_documentation.md
@@ -1,5 +1,68 @@
 ## Migration
 
+### ver 9.0.0
+
+- chore: Bump minimum supported SDK version to `Flutter 3.22/Dart 3.4`.
+
+```
+environment:
+   // sdk: ">=3.0.0 <4.0.0"
+   // flutter: ">=3.10.0"
+   sdk: ^3.4.0
+   flutter: ">=3.22.0"
+```
+
+- chore: Bump `kotlin_version(1.7.10 -> 1.9.10)`, `gradle(7.3.0 -> 8.6.0)` for Android 15.
+
+```
+[android/settings.gradle]
+plugins {
+    // id "com.android.application" version "7.3.0" apply false
+    // id "org.jetbrains.kotlin.android" version "1.7.10" apply false
+    id "com.android.application" version "8.6.0" apply false
+    id "org.jetbrains.kotlin.android" version "1.9.10" apply false
+}
+
+[android/gradle/wrapper/gradle-wrapper.properties]
+// distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-all.zip
+
+[android/app/build.gradle]
+android {
+    // compileSdk 34
+    compileSdk 35
+    
+    compileOptions {
+        // sourceCompatibility JavaVersion.VERSION_1_8
+        // targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
+    }
+
+    kotlinOptions {
+        // jvmTarget = JavaVersion.VERSION_1_8
+        jvmTarget = JavaVersion.VERSION_11
+    }
+    
+    defaultConfig {
+        // targetSdkVersion 34
+        targetSdkVersion 35
+    }
+}
+```
+
+- feat: Add `isTimeout` param to the onDestroy callback.
+
+```dart
+// from
+@override
+Future<void> onDestroy(DateTime timestamp) async {}
+
+// to
+@override
+Future<void> onDestroy(DateTime timestamp, bool isTimeout) async {}
+```
+
 ### ver 8.16.0
 
 - Change `ServiceRequestResult` class to `sealed class` for improved code readability.

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -49,8 +49,8 @@ class MyTaskHandler extends TaskHandler {
 
   // Called when the task is destroyed.
   @override
-  Future<void> onDestroy(DateTime timestamp) async {
-    print('onDestroy');
+  Future<void> onDestroy(DateTime timestamp, bool isTimeout) async {
+    print('onDestroy(isTimeout: $isTimeout)');
   }
 
   // Called when data is sent using `FlutterForegroundTask.sendDataToTask`.

--- a/lib/flutter_foreground_task_method_channel.dart
+++ b/lib/flutter_foreground_task_method_channel.dart
@@ -133,7 +133,8 @@ class MethodChannelFlutterForegroundTask extends FlutterForegroundTaskPlatform {
         handler.onRepeatEvent(timestamp);
         break;
       case 'onDestroy':
-        await handler.onDestroy(timestamp);
+        final bool isTimeout = call.arguments ?? false;
+        await handler.onDestroy(timestamp, isTimeout);
         break;
       case 'onReceiveData':
         dynamic data = call.arguments;

--- a/lib/task_handler.dart
+++ b/lib/task_handler.dart
@@ -13,7 +13,7 @@ abstract class TaskHandler {
   void onRepeatEvent(DateTime timestamp);
 
   /// Called when the task is destroyed.
-  Future<void> onDestroy(DateTime timestamp);
+  Future<void> onDestroy(DateTime timestamp, bool isTimeout);
 
   /// Called when data is sent using [FlutterForegroundTask.sendDataToTask].
   void onReceiveData(Object data) {}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_foreground_task
 description: This plugin is used to implement a foreground service on the Android platform.
-version: 8.17.0
+version: 9.0.0
 homepage: https://github.com/Dev-hwang/flutter_foreground_task
 
 environment:

--- a/test/task_handler_test.dart
+++ b/test/task_handler_test.dart
@@ -69,7 +69,7 @@ void main() {
       const String method = TaskEventMethod.onDestroy;
 
       await platformChannel.mBGChannel.invokeMethod(method);
-      expect(taskHandler.log.last, isTaskEvent(method));
+      expect(taskHandler.log.last, isTaskEvent(method, false));
     });
 
     test('onReceiveData', () async {
@@ -294,8 +294,8 @@ class TestTaskHandler extends TaskHandler {
   }
 
   @override
-  Future<void> onDestroy(DateTime timestamp) async {
-    log.add(const TaskEvent(method: TaskEventMethod.onDestroy));
+  Future<void> onDestroy(DateTime timestamp, bool isTimeout) async {
+    log.add(TaskEvent(method: TaskEventMethod.onDestroy, data: isTimeout));
   }
 
   @override


### PR DESCRIPTION
## 9.0.0

* [**CHORE**] Bump minimum supported SDK version to `Flutter 3.22/Dart 3.4`
* [**CHORE**] Bump `kotlin_version(1.7.10 -> 1.9.10)`, `gradle(7.3.0 -> 8.6.0)` for Android 15
* [**FEAT**] Add `isTimeout` param to the onDestroy callback
* [**FIX**] Fix "null object" error [#332](https://github.com/Dev-hwang/flutter_foreground_task/issues/332)
* [**FIX**] Fix "Reply already submitted" error [#330](https://github.com/Dev-hwang/flutter_foreground_task/issues/330)
* [**FIX**] Prevent crash by catching exceptions during foreground service start
* Check [migration_documentation](./documentation/migration_documentation.md) for changes