### PR TITLE
[ANDROID-35] the service is automatically restarted when the time limit is reached

### DIFF
--- a/android/src/main/kotlin/com/pravera/flutter_foreground_task/PreferencesKey.kt
+++ b/android/src/main/kotlin/com/pravera/flutter_foreground_task/PreferencesKey.kt
@@ -52,6 +52,7 @@ object PreferencesKey {
     const val AUTO_RUN_ON_MY_PACKAGE_REPLACED = "autoRunOnMyPackageReplaced"
     const val ALLOW_WAKE_LOCK = "allowWakeLock"
     const val ALLOW_WIFI_LOCK = "allowWifiLock"
+    const val ALLOW_AUTO_RESTART = "allowAutoRestart"
 
     // task data
     const val CALLBACK_HANDLE = "callbackHandle"

--- a/android/src/main/kotlin/com/pravera/flutter_foreground_task/models/ForegroundTaskOptions.kt
+++ b/android/src/main/kotlin/com/pravera/flutter_foreground_task/models/ForegroundTaskOptions.kt
@@ -9,7 +9,8 @@ data class ForegroundTaskOptions(
     val autoRunOnBoot: Boolean,
     val autoRunOnMyPackageReplaced: Boolean,
     val allowWakeLock: Boolean,
-    val allowWifiLock: Boolean
+    val allowWifiLock: Boolean,
+    val allowAutoRestart: Boolean
 ) {
     companion object {
         fun getData(context: Context): ForegroundTaskOptions {
@@ -34,13 +35,15 @@ data class ForegroundTaskOptions(
             val autoRunOnMyPackageReplaced = prefs.getBoolean(PrefsKey.AUTO_RUN_ON_MY_PACKAGE_REPLACED, false)
             val allowWakeLock = prefs.getBoolean(PrefsKey.ALLOW_WAKE_LOCK, true)
             val allowWifiLock = prefs.getBoolean(PrefsKey.ALLOW_WIFI_LOCK, false)
+            val allowAutoRestart = prefs.getBoolean(PrefsKey.ALLOW_AUTO_RESTART, false)
 
             return ForegroundTaskOptions(
                 eventAction = eventAction,
                 autoRunOnBoot = autoRunOnBoot,
                 autoRunOnMyPackageReplaced = autoRunOnMyPackageReplaced,
                 allowWakeLock = allowWakeLock,
-                allowWifiLock = allowWifiLock
+                allowWifiLock = allowWifiLock,
+                allowAutoRestart = allowAutoRestart,
             )
         }
 
@@ -58,6 +61,7 @@ data class ForegroundTaskOptions(
             val autoRunOnMyPackageReplaced = map?.get(PrefsKey.AUTO_RUN_ON_MY_PACKAGE_REPLACED) as? Boolean ?: false
             val allowWakeLock = map?.get(PrefsKey.ALLOW_WAKE_LOCK) as? Boolean ?: true
             val allowWifiLock = map?.get(PrefsKey.ALLOW_WIFI_LOCK) as? Boolean ?: false
+            val allowAutoRestart = map?.get(PrefsKey.ALLOW_AUTO_RESTART) as? Boolean ?: false
 
             with(prefs.edit()) {
                 putString(PrefsKey.TASK_EVENT_ACTION, eventActionJsonString)
@@ -65,6 +69,7 @@ data class ForegroundTaskOptions(
                 putBoolean(PrefsKey.AUTO_RUN_ON_MY_PACKAGE_REPLACED, autoRunOnMyPackageReplaced)
                 putBoolean(PrefsKey.ALLOW_WAKE_LOCK, allowWakeLock)
                 putBoolean(PrefsKey.ALLOW_WIFI_LOCK, allowWifiLock)
+                putBoolean(PrefsKey.ALLOW_AUTO_RESTART, allowAutoRestart)
                 commit()
             }
         }
@@ -83,6 +88,7 @@ data class ForegroundTaskOptions(
             val autoRunOnMyPackageReplaced = map?.get(PrefsKey.AUTO_RUN_ON_MY_PACKAGE_REPLACED) as? Boolean
             val allowWakeLock = map?.get(PrefsKey.ALLOW_WAKE_LOCK) as? Boolean
             val allowWifiLock = map?.get(PrefsKey.ALLOW_WIFI_LOCK) as? Boolean
+            val allowAutoRestart = map?.get(PrefsKey.ALLOW_AUTO_RESTART) as? Boolean
 
             with(prefs.edit()) {
                 eventActionJsonString?.let { putString(PrefsKey.TASK_EVENT_ACTION, it) }
@@ -90,6 +96,7 @@ data class ForegroundTaskOptions(
                 autoRunOnMyPackageReplaced?.let { putBoolean(PrefsKey.AUTO_RUN_ON_MY_PACKAGE_REPLACED, it) }
                 allowWakeLock?.let { putBoolean(PrefsKey.ALLOW_WAKE_LOCK, it) }
                 allowWifiLock?.let { putBoolean(PrefsKey.ALLOW_WIFI_LOCK, it) }
+                allowAutoRestart?.let { putBoolean(PrefsKey.ALLOW_AUTO_RESTART, it) }
                 commit()
             }
         }

--- a/android/src/main/kotlin/com/pravera/flutter_foreground_task/service/ForegroundService.kt
+++ b/android/src/main/kotlin/com/pravera/flutter_foreground_task/service/ForegroundService.kt
@@ -194,7 +194,8 @@ class ForegroundService : Service() {
         if (::foregroundServiceStatus.isInitialized) {
             isCorrectlyStopped = foregroundServiceStatus.isCorrectlyStopped()
         }
-        if (!isCorrectlyStopped && !ForegroundServiceUtils.isSetStopWithTaskFlag(this)) {
+        val allowAutoRestart = foregroundTaskOptions.allowAutoRestart
+        if (allowAutoRestart && !isCorrectlyStopped && !ForegroundServiceUtils.isSetStopWithTaskFlag(this)) {
             Log.e(TAG, "The service will be restarted after 5 seconds because it wasn't properly stopped.")
             RestartReceiver.setRestartAlarm(this, 5000)
         }

--- a/lib/models/foreground_task_options.dart
+++ b/lib/models/foreground_task_options.dart
@@ -9,6 +9,7 @@ class ForegroundTaskOptions {
     this.autoRunOnMyPackageReplaced = false,
     this.allowWakeLock = true,
     this.allowWifiLock = false,
+    this.allowAutoRestart = true,
   });
 
   /// The action of onRepeatEvent in [TaskHandler].
@@ -32,6 +33,11 @@ class ForegroundTaskOptions {
   /// https://developer.android.com/reference/android/net/wifi/WifiManager.WifiLock.html
   final bool allowWifiLock;
 
+  /// Allows an application to automatically restart when the app is killed by the system.
+  ///
+  /// https://developer.android.com/about/versions/15/behavior-changes-15?hl=pt-br#datasync-timeout
+  final bool allowAutoRestart;
+
   /// Returns the data fields of [ForegroundTaskOptions] in JSON format.
   Map<String, dynamic> toJson() {
     return {
@@ -40,6 +46,7 @@ class ForegroundTaskOptions {
       'autoRunOnMyPackageReplaced': autoRunOnMyPackageReplaced,
       'allowWakeLock': allowWakeLock,
       'allowWifiLock': allowWifiLock,
+      'allowAutoRestart': allowAutoRestart,
     };
   }
 
@@ -50,13 +57,14 @@ class ForegroundTaskOptions {
     bool? autoRunOnMyPackageReplaced,
     bool? allowWakeLock,
     bool? allowWifiLock,
+    bool? allowAutoRestart,
   }) =>
       ForegroundTaskOptions(
         eventAction: eventAction ?? this.eventAction,
         autoRunOnBoot: autoRunOnBoot ?? this.autoRunOnBoot,
-        autoRunOnMyPackageReplaced:
-            autoRunOnMyPackageReplaced ?? this.autoRunOnMyPackageReplaced,
+        autoRunOnMyPackageReplaced: autoRunOnMyPackageReplaced ?? this.autoRunOnMyPackageReplaced,
         allowWakeLock: allowWakeLock ?? this.allowWakeLock,
         allowWifiLock: allowWifiLock ?? this.allowWifiLock,
+        allowAutoRestart: allowAutoRestart ?? this.allowAutoRestart,
       );
 }


### PR DESCRIPTION
In Android 35, when the foreground service is of the dataSync type, the execution timeout without the app being called to the foreground is 6 hours.

In the ForegroundService.kt package, onDestroy method,
if !isCorrectlyStopped is false
and !ForegroundServiceUtils.isSetStopWithTaskFlag(this) is false

the service will be automatically restarted, however, generating an error. I will put the prints of the error below

![Image](https://github.com/user-attachments/assets/0834882d-c53e-46a4-86c9-3c628784e3b8)

![Image](https://github.com/user-attachments/assets/45893228-566f-41b5-b3c5-929d92c9b318)

fix: create new param in ForegroundTaskOption dart class

and see this on onDestroy
![image](https://github.com/user-attachments/assets/52d34397-9a9d-4d59-8931-c8af4bf7c5c2)

![image](https://github.com/user-attachments/assets/49f9fd33-7504-4312-bc6a-6b4c92260f86)


