### PR TITLE
Fix FLAG_STOP_WITH_TASK bitmask check

### DIFF
--- a/android/src/main/kotlin/com/pravera/flutter_foreground_task/utils/ForegroundServiceUtils.kt
+++ b/android/src/main/kotlin/com/pravera/flutter_foreground_task/utils/ForegroundServiceUtils.kt
@@ -17,7 +17,7 @@ class ForegroundServiceUtils {
                 val pm = context.packageManager
                 val cName = ComponentName(context, ForegroundService::class.java)
                 val flags = pm.getServiceInfo(cName, PackageManager.GET_META_DATA).flags
-                (flags and ServiceInfo.FLAG_STOP_WITH_TASK) == 1
+                (flags and ServiceInfo.FLAG_STOP_WITH_TASK) != 0
             } catch (e: NameNotFoundException) {
                 Log.e(TAG, "isSetStopWithTaskFlag >> The service component cannot be found on the system.")
                 true


### PR DESCRIPTION
The foreground service currently checks the FLAG_STOP_WITH_TASK service flag like this:

`(flags and ServiceInfo.FLAG_STOP_WITH_TASK) == 1`

This is incorrect for a bitmask. FLAG_STOP_WITH_TASK is not guaranteed to have the value 1, so this comparison can fail even when the flag is set.

This PR fixes the check to correctly test for a non-zero bit:

`(flags and ServiceInfo.FLAG_STOP_WITH_TASK) != 0`