### PR TITLE
fix(android): Prevent crash in onDestroy

### DIFF
--- a/android/src/main/kotlin/com/pravera/flutter_foreground_task/service/ForegroundService.kt
+++ b/android/src/main/kotlin/com/pravera/flutter_foreground_task/service/ForegroundService.kt
@@ -204,10 +204,14 @@ class ForegroundService : Service() {
         if (::foregroundServiceStatus.isInitialized) {
             isCorrectlyStopped = foregroundServiceStatus.isCorrectlyStopped()
         }
-        val allowAutoRestart = foregroundTaskOptions.allowAutoRestart
-        if (allowAutoRestart && !isCorrectlyStopped && !ForegroundServiceUtils.isSetStopWithTaskFlag(this)) {
-            Log.e(TAG, "The service will be restarted after 5 seconds because it wasn't properly stopped.")
-            RestartReceiver.setRestartAlarm(this, 5000)
+
+        // Safely handle auto-restart by checking if options are initialized.
+        if (::foregroundTaskOptions.isInitialized) {
+            val allowAutoRestart = foregroundTaskOptions.allowAutoRestart
+            if (allowAutoRestart && !isCorrectlyStopped && !ForegroundServiceUtils.isSetStopWithTaskFlag(this)) {
+                Log.e(TAG, "The service will be restarted after 5 seconds because it wasn't properly stopped.")
+                RestartReceiver.setRestartAlarm(this, 5000)
+            }
         }
     }
 


### PR DESCRIPTION
### Description

This PR resolves a critical `UninitializedPropertyAccessException` that occurs when the `ForegroundService` is destroyed by the Android OS before the `foregroundTaskOptions` property has been initialized.

Under certain conditions (e.g., the system reclaiming resources while the app is in the background), `onDestroy()` can be called without `onStartCommand()` having run, leading to a crash as the `lateinit` property is accessed before it has a value.

### The Fix

The solution is to add a defensive, idiomatic Kotlin check (`::foregroundTaskOptions.isInitialized`) before accessing the property in the `onDestroy` method. This ensures the app does not crash in this edge case and safely skips the auto-restart logic when the service's options were never loaded.

### Verification

This change is a standard, low-risk solution for this common Android/Kotlin lifecycle issue.
- If `foregroundTaskOptions` is initialized, the behavior is unchanged.
- If it is not initialized, the crash is prevented.

This directly addresses the root cause of the crash reports related to `lateinit property foregroundTaskOptions has not been initialized`.