### PR TITLE
feat(ios): Add UIScene life cycle support

### DIFF
--- a/ios/Classes/FlutterForegroundTaskPlugin.m
+++ b/ios/Classes/FlutterForegroundTaskPlugin.m
@@ -16,3 +16,12 @@
   [SwiftFlutterForegroundTaskPlugin setPluginRegistrantCallback:callback];
 }
 @end
+
+@interface FlutterForegroundTaskEarlyRegistration : NSObject
+@end
+
+@implementation FlutterForegroundTaskEarlyRegistration
++ (void)load {
+  [SwiftFlutterForegroundTaskPlugin registerAppRefreshForBackgroundLaunch];
+}
+@end

--- a/ios/Classes/SwiftFlutterForegroundTaskPlugin.swift
+++ b/ios/Classes/SwiftFlutterForegroundTaskPlugin.swift
@@ -2,7 +2,7 @@ import Flutter
 import UIKit
 import BackgroundTasks
 
-public class SwiftFlutterForegroundTaskPlugin: NSObject, FlutterPlugin {
+public class SwiftFlutterForegroundTaskPlugin: NSObject, FlutterPlugin, FlutterSceneLifeCycleDelegate {
   // ====================== Plugin ======================
   static private(set) var registerPlugins: FlutterPluginRegistrantCallback? = nil
   
@@ -16,10 +16,19 @@ public class SwiftFlutterForegroundTaskPlugin: NSObject, FlutterPlugin {
     instance.initServices()
     instance.initChannels(registrar.messenger())
     registrar.addApplicationDelegate(instance)
+    registrar.addSceneDelegate(instance)
   }
   
   public static func setPluginRegistrantCallback(_ callback: @escaping FlutterPluginRegistrantCallback) {
     registerPlugins = callback
+  }
+
+  @objc public static func registerAppRefreshForBackgroundLaunch() {
+    if #available(iOS 13.0, *) {
+      let permitted = Bundle.main.object(forInfoDictionaryKey: "BGTaskSchedulerPermittedIdentifiers") as? [String] ?? []
+      guard permitted.contains(refreshIdentifier) else { return }
+      registerAppRefresh()
+    }
   }
   
   public static func addTaskLifecycleListener(_ listener: FlutterForegroundTaskLifecycleListener) {
@@ -115,6 +124,12 @@ public class SwiftFlutterForegroundTaskPlugin: NSObject, FlutterPlugin {
     sleep(5)
   }
   
+  // ================ Scene Lifecycle ===================
+  @available(iOS 13.0, *)
+  public func sceneDidEnterBackground(_ scene: UIScene) {
+    SwiftFlutterForegroundTaskPlugin.scheduleAppRefresh()
+  }
+
   // ================= Service Delegate =================
   @available(iOS 10.0, *)
   public func userNotificationCenter(_ center: UNUserNotificationCenter,
@@ -132,9 +147,12 @@ public class SwiftFlutterForegroundTaskPlugin: NSObject, FlutterPlugin {
   
   // ============== Background App Refresh ==============
   public static var refreshIdentifier: String = "com.pravera.flutter_foreground_task.refresh"
+  private static var isBgTaskRegistered: Bool = false
 
   @available(iOS 13.0, *)
   private static func registerAppRefresh() {
+    guard !isBgTaskRegistered else { return }
+    isBgTaskRegistered = true
     BGTaskScheduler.shared.register(forTaskWithIdentifier: refreshIdentifier, using: nil) { task in
       handleAppRefresh(task: task as! BGAppRefreshTask)
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/Dev-hwang/flutter_foreground_task
 
 environment:
   sdk: ^3.4.0
-  flutter: ">=3.22.0"
+  flutter: ">=3.38.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
**feat(ios): Add UIScene lifecycle support**

Closes #376.

Apple requires all UIKit apps built with the latest SDK to adopt UIScene lifecycle. In UIScene apps, `applicationDidEnterBackground` is never called, which prevented background app refresh from being scheduled. This adds the necessary UIScene support per the [Flutter plugin migration guide](https://docs.flutter.dev/release/breaking-changes/uiscenedelegate).

**Changes:**

- `SwiftFlutterForegroundTaskPlugin` now conforms to `FlutterSceneLifeCycleDelegate` and registers itself via `registrar.addSceneDelegate(instance)` so it receives scene lifecycle callbacks
- `sceneDidEnterBackground(_:)` added to schedule background app refresh in UIScene apps, mirroring what `applicationDidEnterBackground` does for non-UIScene apps — both coexist for backward compatibility
- `FlutterForegroundTaskEarlyRegistration +load` added in the Obj-C layer to register the `BGTaskScheduler` handler at binary load time, before Flutter initialises — required for background launch scenarios where iOS wakes the app to service a refresh task
- `isBgTaskRegistered` guard added to `registerAppRefresh()` to prevent a double-registration crash during the UIScene transition period, when host apps may invoke `GeneratedPluginRegistrant.register(with:)` from both the old and new template locations
- Flutter minimum bumped from `>=3.22.0` to `>=3.38.0`, the version that introduced `addSceneDelegate`