### PR TITLE
Migrate to built-in Kotlin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 9.3.0
+
+* [**CHORE**] Migrate to built-in Kotlin. AGP 9.0 will remove support for plugins that apply the Kotlin Gradle Plugin. Removes `apply plugin: "kotlin-android"` and the KGP classpath from `android/build.gradle`, and the same from `example/android/app/build.gradle`. Bumps minimum Flutter version to 3.44.0 and Dart SDK to 3.12.0 as required by the new `kotlin.compilerOptions` DSL.
+
 ## 9.2.2
 
 * [**FIX**] Resolved frequent ForegroundServiceDidNotStartInTime and ForegroundServiceDidNotStopInTime exceptions by avoiding redundant foreground service start contracts. [#377](https://github.com/Dev-hwang/flutter_foreground_task/pull/377)

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,6 @@ group 'com.pravera.flutter_foreground_task'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.9.10'
     repositories {
         google()
         mavenCentral()
@@ -10,7 +9,6 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:8.6.0'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
 
@@ -22,7 +20,6 @@ rootProject.allprojects {
 }
 
 apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
 
 android {
     // Conditional for compatibility with AGP <4.2.
@@ -35,10 +32,6 @@ android {
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_11
         targetCompatibility JavaVersion.VERSION_11
-    }
-
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_11
     }
 
     sourceSets {
@@ -69,5 +62,11 @@ android {
                 showStandardStreams = true
             }
         }
+    }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11
     }
 }

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -1,6 +1,5 @@
 plugins {
     id "com.android.application"
-    id "kotlin-android"
     id "dev.flutter.flutter-gradle-plugin"
 }
 
@@ -31,10 +30,6 @@ android {
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_11
         targetCompatibility JavaVersion.VERSION_11
-    }
-
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_11
     }
 
     sourceSets {
@@ -72,3 +67,9 @@ flutter {
 }
 
 dependencies {}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11
+    }
+}

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -2,3 +2,5 @@ org.gradle.jvmargs=-Xmx4G -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
 android.enableJetifier=true
 android.enableR8=true
+android.builtInKotlin=true
+android.newDsl=true

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,11 @@
 name: flutter_foreground_task
 description: This plugin is used to implement a foreground service on the Android platform.
-version: 9.2.2
+version: 9.3.0
 homepage: https://github.com/Dev-hwang/flutter_foreground_task
 
 environment:
-  sdk: ^3.4.0
-  flutter: ">=3.22.0"
+  sdk: ^3.12.0
+  flutter: ">=3.44.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
Migrates the plugin to use built-in Kotlin per the official Flutter
migration guide:
https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors

AGP 9.0 will remove support for plugins that apply the Kotlin Gradle
Plugin. This PR removes the legacy `apply plugin: "kotlin-android"`
line and the KGP classpath from `android/build.gradle`, and the same
from the example app's `example/android/app/build.gradle`.

The example app builds cleanly with `flutter build apk --debug` on
Flutter 3.44.1 with no KGP deprecation warnings.

Bumps the minimum Flutter version to 3.44.0 and Dart SDK to 3.12.0,
as required by the new `kotlin.compilerOptions` DSL.

Fixes the warning: "Your app uses the following plugins that apply
Kotlin Gradle Plugin (KGP)".