### PR TITLE
Add `serviceTypes` as an argument to the `updateService` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -490,6 +490,15 @@ class SecondTaskHandler extends TaskHandler {
 }
 ```
 
+> [!NOTE]
+>You can optionally specify serviceTypes in FlutterForegroundTask.updateService() to update the foreground service types without restarting the service.
+>
+>This is useful for applications that need to run a foreground service continuously on Android 15 or later. Some foreground service types, such as ForegroundServiceTypes.dataSync and ForegroundServiceTypes.mediaProcessing, are subject to Android's foreground service timeout restrictions.
+>
+>By switching to another appropriate foreground service type with updateService(), you can seamlessly transition between service types without stopping and restarting the service, avoiding any gap where no foreground service is running.
+>
+>If serviceTypes is not specified, the current foreground service types will remain unchanged.
+
 7. If you no longer use the service, call `FlutterForegroundTask.stopService`.
 
 ```dart

--- a/android/src/main/kotlin/com/pravera/flutter_foreground_task/models/ForegroundServiceTypes.kt
+++ b/android/src/main/kotlin/com/pravera/flutter_foreground_task/models/ForegroundServiceTypes.kt
@@ -45,6 +45,32 @@ data class ForegroundServiceTypes(val value: Int) {
             }
         }
 
+        fun updateData(context: Context, map: Map<*, *>?) {
+            val prefs = context.getSharedPreferences(
+                PreferencesKey.FOREGROUND_SERVICE_TYPES_PREFS, Context.MODE_PRIVATE)
+
+            var value = 0
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                val serviceTypes = map?.get(PreferencesKey.FOREGROUND_SERVICE_TYPES) as? List<*>
+                if (serviceTypes != null) {
+                    for (serviceType in serviceTypes) {
+                        getForegroundServiceTypeFlag(serviceType)?.let {
+                            value = value or it
+                        }
+                    }
+                }
+            }
+
+            // not none type
+            if (value > 0) {
+                with(prefs.edit()) {
+                    clear()
+                    putInt(PreferencesKey.FOREGROUND_SERVICE_TYPES, value)
+                    commit()
+                }
+            }
+        }
+
         fun clearData(context: Context) {
             val prefs = context.getSharedPreferences(
                 PreferencesKey.FOREGROUND_SERVICE_TYPES_PREFS, Context.MODE_PRIVATE)

--- a/android/src/main/kotlin/com/pravera/flutter_foreground_task/service/ForegroundServiceManager.kt
+++ b/android/src/main/kotlin/com/pravera/flutter_foreground_task/service/ForegroundServiceManager.kt
@@ -12,6 +12,7 @@ import com.pravera.flutter_foreground_task.models.ForegroundTaskData
 import com.pravera.flutter_foreground_task.models.ForegroundTaskOptions
 import com.pravera.flutter_foreground_task.models.NotificationContent
 import com.pravera.flutter_foreground_task.models.NotificationOptions
+import com.pravera.flutter_foreground_task.PreferencesKey
 
 /**
  * A class that provides foreground service control and management functions.
@@ -57,13 +58,22 @@ class ForegroundServiceManager {
 		val nIntent = Intent(context, ForegroundService::class.java)
 		val argsMap = arguments as? Map<*, *>
 		ForegroundServiceStatus.setData(context, ForegroundServiceAction.API_UPDATE)
+		ForegroundServiceTypes.updateData(context, argsMap)
 		ForegroundTaskOptions.updateData(context, argsMap)
 		ForegroundTaskData.updateData(context, argsMap)
 		NotificationContent.updateData(context, argsMap)
-		// Use startService instead of startForegroundService because the service
-		// is already running in the foreground and we only need to deliver the
-		// update command. This avoids the startForeground() contract requirement.
-		context.startService(nIntent)
+
+		val serviceTypes = argsMap?.get(PreferencesKey.FOREGROUND_SERVICE_TYPES) as? List<*>
+		if (serviceTypes.isNullOrEmpty()) {
+			// Use startService instead of startForegroundService because the service
+			// is already running in the foreground and we only need to deliver the
+			// update command. This avoids the startForeground() contract requirement.
+			context.startService(nIntent)
+		} else {
+			// If a type is specified, use `startForegroundService` to update the type.
+			ContextCompat.startForegroundService(context, nIntent)
+		}
+		
 	}
 
 	/** Stop the foreground service. */

--- a/lib/flutter_foreground_task.dart
+++ b/lib/flutter_foreground_task.dart
@@ -157,6 +157,7 @@ class FlutterForegroundTask {
   /// Update the foreground service.
   static Future<ServiceRequestResult> updateService({
     ForegroundTaskOptions? foregroundTaskOptions,
+    List<ForegroundServiceTypes>? serviceTypes,
     String? notificationTitle,
     String? notificationText,
     NotificationIcon? notificationIcon,
@@ -171,6 +172,7 @@ class FlutterForegroundTask {
 
       await _platform.updateService(
         foregroundTaskOptions: foregroundTaskOptions,
+        serviceTypes: serviceTypes,
         notificationText: notificationText,
         notificationTitle: notificationTitle,
         notificationIcon: notificationIcon,

--- a/lib/flutter_foreground_task_method_channel.dart
+++ b/lib/flutter_foreground_task_method_channel.dart
@@ -71,6 +71,7 @@ class MethodChannelFlutterForegroundTask extends FlutterForegroundTaskPlatform {
   @override
   Future<void> updateService({
     ForegroundTaskOptions? foregroundTaskOptions,
+    List<ForegroundServiceTypes>? serviceTypes,
     String? notificationTitle,
     String? notificationText,
     NotificationIcon? notificationIcon,
@@ -79,6 +80,7 @@ class MethodChannelFlutterForegroundTask extends FlutterForegroundTaskPlatform {
     Function? callback,
   }) async {
     final Map<String, dynamic> optionsJson = ServiceUpdateOptions(
+      serviceTypes: serviceTypes,
       foregroundTaskOptions: foregroundTaskOptions,
       notificationContentTitle: notificationTitle,
       notificationContentText: notificationText,

--- a/lib/flutter_foreground_task_platform_interface.dart
+++ b/lib/flutter_foreground_task_platform_interface.dart
@@ -55,6 +55,7 @@ abstract class FlutterForegroundTaskPlatform extends PlatformInterface {
 
   Future<void> updateService({
     ForegroundTaskOptions? foregroundTaskOptions,
+    List<ForegroundServiceTypes>? serviceTypes,
     String? notificationTitle,
     String? notificationText,
     NotificationIcon? notificationIcon,

--- a/lib/models/service_options.dart
+++ b/lib/models/service_options.dart
@@ -64,6 +64,7 @@ class ServiceStartOptions {
 
 class ServiceUpdateOptions {
   const ServiceUpdateOptions({
+    this.serviceTypes,
     required this.foregroundTaskOptions,
     required this.notificationContentTitle,
     required this.notificationContentText,
@@ -73,6 +74,7 @@ class ServiceUpdateOptions {
     this.callback,
   });
 
+  final List<ForegroundServiceTypes>? serviceTypes;
   final ForegroundTaskOptions? foregroundTaskOptions;
   final String? notificationContentTitle;
   final String? notificationContentText;
@@ -83,6 +85,7 @@ class ServiceUpdateOptions {
 
   Map<String, dynamic> toJson(Platform platform) {
     final Map<String, dynamic> json = {
+      'serviceTypes': serviceTypes?.map((e) => e.rawValue).toList(),
       'notificationContentTitle': notificationContentTitle,
       'notificationContentText': notificationContentText,
       'icon': notificationIcon?.toJson(),


### PR DESCRIPTION
### Motivation

Android 15 introduces timeout restrictions for some foreground service types
such as dataSync and mediaProcessing.

Currently, changing the foreground service type requires stopping and
restarting the service, which may create a period where no foreground
service is running.

This PR allows updating foreground service types through updateService()
without restarting the service.

### Changes

- Added optional serviceTypes parameter to updateService()
- Updated Android implementation to refresh foreground service types
  using startForeground(...)
- Updated README with usage examples and notes

### Verification

Verified on Android 14, Android 16.

- dataSync -> connectedDevice
- connectedDevice -> dataSync
- notification updates continue to work
- service remains running without restart