### PR TITLE
fix(ios): include the Obj-C shim in the podspec source_files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 11.0.3
+
+* [**FIX-iOS**] Include the objective-c shim in the podspec source_files so it is compiled under CocoaPods
+
 ## 11.0.2
 
 * [**FIX-iOS**] Add objective-c shim for FlutterForegroundTaskPlugin

--- a/ios/flutter_foreground_task.podspec
+++ b/ios/flutter_foreground_task.podspec
@@ -13,7 +13,7 @@ A new Flutter plugin.
   s.license          = { :file => '../LICENSE' }
   s.author           = { 'Your Company' => 'email@example.com' }
   s.source           = { :path => '.' }
-  s.source_files = 'flutter_foreground_task/Sources/flutter_foreground_task/**/*.swift', 'Classes/**/*.{h,m}'
+  s.source_files = 'flutter_foreground_task/Sources/flutter_foreground_task/**/*.swift', 'flutter_foreground_task/Classes/**/*.{h,m}'
   s.dependency 'Flutter'
   s.platform = :ios, '12.0'
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_foreground_task
 description: This plugin is used to implement a foreground service on the Android platform.
-version: 11.0.2
+version: 11.0.3
 homepage: https://github.com/Dev-hwang/flutter_foreground_task
 
 environment:


### PR DESCRIPTION
### Problem

The Obj-C shim added in 11.0.2 is never compiled under CocoaPods, so 11.0.2 still fails exactly like 11.0.1 for non-SPM apps (#395, #396):

```
Semantic Issue (Xcode): Unknown receiver 'FlutterForegroundTaskPlugin';
did you mean 'SwiftFlutterForegroundTaskPlugin'?
ios/Runner/GeneratedPluginRegistrant.m
```

### Cause

Both globs in `source_files` are resolved relative to the podspec's directory (`ios/`). The Swift glob carries the `flutter_foreground_task/` prefix, but the Obj-C one does not:

```ruby
s.source_files = 'flutter_foreground_task/Sources/flutter_foreground_task/**/*.swift',
                 'Classes/**/*.{h,m}'
```

So CocoaPods looks for `ios/Classes/`, while the files actually live in `ios/flutter_foreground_task/Classes/`. The glob matches nothing, the shim is silently dropped from the pod, and `FlutterForegroundTaskPlugin` never exists for the generated registrant — the class is otherwise only declared in `FlutterForegroundTaskPluginSPMBridge.swift` behind `#if SWIFT_PACKAGE`, which is not defined for CocoaPods builds.

### Fix

Add the missing prefix so the shim is part of the pod.

### Verification

Built a real CocoaPods (non-SPM) app against this repo, wiping `Pods/` and `build/` before each run and changing only this glob:

| `source_files` Obj-C glob | Result | `FlutterForegroundTaskPlugin.m` refs in generated `Pods.xcodeproj` |
| --- | --- | --- |
| `'Classes/**/*.{h,m}'` (11.0.2 as published) | ❌ `Unknown receiver 'FlutterForegroundTaskPlugin'` | 0 |
| `'flutter_foreground_task/Classes/**/*.{h,m}'` (this PR) | ✅ builds and links | 4 |

Environment: Flutter 3.47.2, CocoaPods 1.16.2, Xcode iOS device release build, SPM disabled (`flutter config --no-enable-swift-package-manager`).

Closes #395
Closes #396
